### PR TITLE
fix typst template repeated "#set document("

### DIFF
--- a/ox-typst.el
+++ b/ox-typst.el
@@ -436,8 +436,8 @@ The function should return the string to be exported."
           (format "title: \"%s\"" (car title)))
         (when author
           (or (when email
-                (format "#set document(title: \"%s\", author: \"<%s> %s\")" (car title) (car author) email))
-              (format "#set document(title: \"%s\", author: \"%s\")" (car title) (car author))))
+                (format ", author: \"<%s> %s\"" (car author) email))
+              (format ", author: \"%s\"" (car author))))
         ")\n"))
      (when language (format "#set text(lang: \"%s\")\n" language))
      (when toc "#outline()\n")


### PR DESCRIPTION
Export to pdf error due to a bad setting header
```typst
#set document(title: "title"#set document(title: "title", author: "author"))
```

The issue occurs in the function of `org-typst-template`

I update this function to fix this issue.


