### PR TITLE
Handle inline remote images & file links

### DIFF
--- a/ox-typst.el
+++ b/ox-typst.el
@@ -318,15 +318,18 @@ The function should return the string to be exported."
   "#linebreak")
 
 (defun org-typst-link (link contents info)
-  (pcase (org-element-property :type link)
-    ((pred (string-equal "radio"))
+  (cond
+    ((string-equal "radio" (org-element-property :type link))
      (when-let ((ref (org-export-get-reference (org-export-resolve-radio-link link info) info)))
        (format "#link(label(%s))[%s]"
                (org-typst--as-string ref)
                (org-trim contents))))
-    ((pred (string-equal "file"))
-     (org-typst--figure (format "#image(%s)" (org-typst--as-string (org-element-property :path link))) link info))
-    (_
+    ((org-export-inline-image-p link)
+     (org-typst--figure (format "#image(%s)"
+                                (org-typst--as-string
+                                 (org-element-property :path (org-export-link-localise link))))
+                        link info))
+    (t
      (when-let ((raw-path (org-element-property :raw-link link)))
        (pcase (org-element-property :type link)
          ("fuzzy"

--- a/test/test.org
+++ b/test/test.org
@@ -252,3 +252,7 @@ After the drawer.
 ** TODO Call Trillian for a date on New Years Eve.
 SCHEDULED: <2004-12-25 Sat>
 DEADLINE: <2004-02-29 Sun>
+
+* File Links
+
+The bibliography is [[./test.bib]], this shouldn't be treated as an image.


### PR DESCRIPTION
* Don't assume all "file" links are images, let `org-export` decide. Otherwise, typst trips over links to local non-image files.
* Support remote images (e.g., from HTTP) if the user has customized `org-export-default-inline-image-rule` to support them. The LaTeX exporter tries to "localize" (download) all links before testing if they're images but... I feel that that's a bit too invasive so I check the inline image rules first.