### PR TITLE
allow log buffer reuse

### DIFF
--- a/ox-typst.el
+++ b/ox-typst.el
@@ -564,15 +564,13 @@ The function should return the string to be exported."
 (defun org-typst-compile (typfile &optional snippet)
   (let* ((log-buf-name "*Org PDF Typst Output*")
          (log-buf (and (not snippet) (get-buffer-create log-buf-name)))
-         (process (format "%s c \"%s\"" org-typst-bin typfile))
-         outfile)
-    (with-current-buffer log-buf
-      (erase-buffer))
-
-    (setq outfile (org-compile-file typfile (list process) "pdf"
-				                            (format "See %S for details" log-buf-name)
-				                            log-buf nil))
-    outfile))
+         (process (format "%s c \"%s\"" org-typst-bin typfile)))
+    (prog1
+	(org-compile-file typfile (list process) "pdf"
+			  (format "See %S for details" log-buf-name)
+			  log-buf nil)
+      (when (zerop (buffer-size log-buf))
+	(kill-buffer log-buf)))))
 
 (require 'oc-typst)
 


### PR DESCRIPTION
Compilation was being stopped by previous errors logged in the `*Org PDF Typst Output*` buffer, which is read-only. This PR allows compilation to proceed, reusing the buffer if there are still errors, or killing it if compilation is successful.