### PR TITLE
Implement theme and syntax highlighting

### DIFF
--- a/.github/workflows/elisp-tests.yml
+++ b/.github/workflows/elisp-tests.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   nix-matrix:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -21,6 +22,7 @@ jobs:
   build:
     needs: nix-matrix
     runs-on: ${{ matrix.image }}
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:
         include: ${{ fromJSON(needs.nix-matrix.outputs.matrix) }}

--- a/.github/workflows/elisp-tests.yml
+++ b/.github/workflows/elisp-tests.yml
@@ -11,7 +11,7 @@ jobs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: nixbuild/nix-quick-install-action@v29
       - id: set-matrix
         name: Generate Nix Matrix
         run: |
@@ -27,6 +27,6 @@ jobs:
     timeout-minutes: 30 # Safety net in case of hanging executable
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
+      - uses: nixbuild/nix-quick-install-action@v29
       - name: Run Tests
-        run: nix run --system ${{ matrix.system }} -L --accept-flake-config ".#checks.${{ matrix.system }}.${{ matrix.target }}"
+        run: nix run --system ${{ matrix.system }} -L ".#checks.${{ matrix.system }}.${{ matrix.target }}"

--- a/.github/workflows/nix-tests.yml
+++ b/.github/workflows/nix-tests.yml
@@ -7,6 +7,7 @@ on:
 jobs:
   check:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v4
       - uses: nixbuild/nix-quick-install-action@v29

--- a/.github/workflows/nix-tests.yml
+++ b/.github/workflows/nix-tests.yml
@@ -9,8 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: cachix/install-nix-action@v30
-
+      - uses: nixbuild/nix-quick-install-action@v29
       - name: Check Formatting
         run: |
           nix run nixpkgs#alejandra -- -c ./**/*.nix

--- a/README.org
+++ b/README.org
@@ -64,13 +64,40 @@ style argument (like =bibliography("./test.bib", style: "apa")=).
 
 ** Math
 
-Currently LaTeX math snippets are not supported. It is currently not possible
-for us to translate these elements into Typst code.
+Org-mode provides a built-in syntax for LaTeX math. However, Typst uses a
+different syntax for math. The syntax of these two modes is incompatible.
 
-Mabye we should one of the following projects for that:
+As a user you have two options: use LaTeX syntax and convert it, or use Typst
+syntax. By setting =org-typst-from-latex-fragment= and
+=org-typst-from-latex-environment= you can control how the Org elements are
+translated. For now, you have to choose between either of them. Mixing them
+throughout the document is not possible.
 
-- https://github.com/msakuta/latypst :: Translate LaTeX snippets to roughly equivalent Typst snippets
-- https://github.com/mitex-rs/mitex :: Emulate LaTeX inside Typst
+For Typst syntax it is best to set these to =#'org-typst-from-latex-with-naive=.
+
+#+BEGIN_SRC elisp
+  (setq org-typst-from-latex-environment #'org-typst-from-latex-with-naive
+        org-typst-from-latex-fragment #'org-typst-from-latex-with-naive)
+#+END_SRC
+
+When you are using the LaTeX syntax, you will need Pandoc to convert the syntax
+to Typst.
+
+#+BEGIN_SRC elisp
+  (setq org-typst-from-latex-environment #'org-typst-from-latex-with-pandoc
+        org-typst-from-latex-fragment #'org-typst-from-latex-with-pandoc)
+#+END_SRC
+
+If none of these methods work for you, then you can always provide your own
+translation functions.
+
+You can also take a look at the files in =tests/math/= to get an idea on how to
+use this functionality. Notice, that in order to use =BIND= you have to enable
+it in Org.
+
+#+BEGIN_SRC elisp
+  (setq org-export-allow-bind-keywords t)
+#+END_SRC
 
 ** Examples
 

--- a/README.org
+++ b/README.org
@@ -1,14 +1,27 @@
 * ox-typst
 
+#+html: <a href="https://melpa.org/#/consult"><img alt="MELPA" src="https://melpa.org/packages/consult-badge.svg"/></a>
+
 Org-mode to Typst exporter.
 
 ** Install
 
-*** Manual
+The package is available trough Melpa.
 
 #+BEGIN_SRC elisp
-(use-package ox-typst
-  :after org)
+  (use-package ox-typst
+    :after org)
+#+END_SRC
+
+*** Recipe
+
+For packages which can use recipes (e.g. Elpaca), the following snippet can be
+used.
+
+#+BEGIN_SRC elisp
+  (use-package ox-typst
+    :after org
+    :ensure (ox-typst :host github :repo "jmpunkt/ox-typst"))
 #+END_SRC
 
 ** Usage

--- a/README.org
+++ b/README.org
@@ -1,10 +1,11 @@
-* ox-typst
+#+title: ox-typst.el - Typst Back-End for Org Export Engine
+#+language: en
 
 #+html: <a href="https://melpa.org/#/consult"><img alt="MELPA" src="https://melpa.org/packages/consult-badge.svg"/></a>
 
 Org-mode to Typst exporter.
 
-** Install
+* Install
 
 The package is available trough Melpa.
 
@@ -13,7 +14,7 @@ The package is available trough Melpa.
     :after org)
 #+END_SRC
 
-*** Recipe
+** Recipe
 
 For packages which can use recipes (e.g. Elpaca), the following snippet can be
 used.
@@ -24,12 +25,12 @@ used.
     :ensure (ox-typst :host github :repo "jmpunkt/ox-typst"))
 #+END_SRC
 
-** Usage
+* Usage
 
 If you use =org-export-dispatch=, then the Typst exporter is
 available with the =y= prefix.
 
-** Insert Typst Code
+* Insert Typst Code
 
 Typst code can be directly used within org-mode by using the
 =#+TYPST:=. The provided string is not escaped by the exporter and is
@@ -48,7 +49,7 @@ Alternatively use an export block.
 #+END_SRC
 
 
-** Themes
+* Themes
 
 Use Typst rules to change the appearance of your document. Include
 these rules at the top level of the document or above the target
@@ -61,7 +62,7 @@ and include them like below.
 
 Alternatively, rules can be put into an export block ([[*Insert Typst Code][Insert Typst Code]]).
 
-** Cite
+* Cite
 
 Typst supports citing and bibliography by default.
 
@@ -75,7 +76,7 @@ Supported styles are listed [[https://typst.app/docs/reference/model/bibliograph
 =apa=) is stringified and put into the =bibliography= function as the
 style argument (like =bibliography("./test.bib", style: "apa")=).
 
-** Math
+* Math
 
 Org-mode provides a built-in syntax for LaTeX math. However, Typst uses a
 different syntax for math. The syntax of these two modes is incompatible.
@@ -112,45 +113,45 @@ it in Org.
   (setq org-export-allow-bind-keywords t)
 #+END_SRC
 
-** Examples
+* Examples
 
 Take a look at =test/test.org= to get an idea how to use the different
 org-mode statements with Typst. For real examples look in the
 =examples= folder.
 
-*** Writing a Letter
+** Writing a Letter
 
 If you want to write a letter using a third party package
 (e.g. https://github.com/Sematre/typst-letter-pro), then take a look
 at =examples/letter.org=.
 
-*** Tests
+** Tests
 
 If you want more examples, maybe look into the tests. The tests contain small
 Org snippets and their Typst representation.
 
-** Development
+* Development
 
-*** Tests
+** Tests
 
 The tests contain small Org snippets and their Typst output. Changing the
 exporter requires to re-run the exporter on all Org files. One should manually
 check if the output matches the expectation. If the output matches the
 expectation, the newly generated files become the new golden output.
 
-**** Generate
+*** Generate
 
 #+BEGIN_SRC org
 emacs --batch -l tests/test.el -f org-typst-test-generate
 #+END_SRC
 
-**** Run
+*** Run
 
 #+BEGIN_SRC org
 emacs --batch -l tests/test.el -f org-typst-test-run
 #+END_SRC
 
-**** With Emacs
+*** With Emacs
 
 It is also possible to use these functions inside Emacs. Navigate to the
 =tests/test.el= file and run =eval-buffer=. The =ox-typst.el= file is

--- a/flake.lock
+++ b/flake.lock
@@ -243,14 +243,27 @@
         "url": "https://ftp.gnu.org/gnu/emacs/emacs-29.4.tar.xz"
       }
     },
+    "emacs-30-1": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1740327883,
+        "narHash": "sha256-UNbaj+6JNDydBh0R92i3ec54lLATo2+th31MghgPC8M=",
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-30.1.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-30.1.tar.xz"
+      }
+    },
     "emacs-release-snapshot": {
       "flake": false,
       "locked": {
-        "lastModified": 1730055145,
-        "narHash": "sha256-EeV7Dy+4hnmXzTYrCLp1YpbxNrycYjUv6H1sfMTz4dE=",
+        "lastModified": 1740899675,
+        "narHash": "sha256-0eecMgI3tPW+hR1oyKqV1a760NsNA2Ja1ncRu3MgHoM=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "9e1abf11fc1c3285cfa631ec71f3836d54e2c8d8",
+        "rev": "365a91622e093fe0fb74b7fee3ff7cc4a0025611",
         "type": "github"
       },
       "original": {
@@ -263,11 +276,11 @@
     "emacs-snapshot": {
       "flake": false,
       "locked": {
-        "lastModified": 1730088836,
-        "narHash": "sha256-P2DuWD9BHWKlpNqH394SbZe+tr857FYtQ8zcBPY6kKA=",
+        "lastModified": 1740976441,
+        "narHash": "sha256-5eD3kiZHb4A2nkLlF3IUUSz8d5bMDvIUYoaTdNurOjI=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "ea685170063b59855322ceffdeaaab4acaf8e388",
+        "rev": "f1950fbdb49abfcea26b995b38223c1e89b3c720",
         "type": "github"
       },
       "original": {
@@ -331,6 +344,7 @@
         "emacs-29-2": "emacs-29-2",
         "emacs-29-3": "emacs-29-3",
         "emacs-29-4": "emacs-29-4",
+        "emacs-30-1": "emacs-30-1",
         "emacs-release-snapshot": "emacs-release-snapshot",
         "emacs-snapshot": "emacs-snapshot",
         "flake-compat": "flake-compat",
@@ -338,11 +352,11 @@
         "nixpkgs": "nixpkgs"
       },
       "locked": {
-        "lastModified": 1730118003,
-        "narHash": "sha256-dZdE8NutQU03+a6K58NPp6KYRSHIsV1/8HwUYJ9aMgs=",
+        "lastModified": 1740999332,
+        "narHash": "sha256-+LBg2e/jPq6pBp9/fjt8MV3ai3mp0jK0geLWmZjwPUU=",
         "owner": "purcell",
         "repo": "nix-emacs-ci",
-        "rev": "863463ac6d677caf28c559915f306975d21c2c2a",
+        "rev": "1ced61cd82219f5406f6fdb2719125677487d084",
         "type": "github"
       },
       "original": {
@@ -353,11 +367,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1727716680,
-        "narHash": "sha256-uMVkVHL4r3QmlZ1JM+UoJwxqa46cgHnIfqGzVlw5ca4=",
+        "lastModified": 1740547748,
+        "narHash": "sha256-Ly2fBL1LscV+KyCqPRufUBuiw+zmWrlJzpWOWbahplg=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "b5b22b42c0d10c7d2463e90a546c394711e3a724",
+        "rev": "3a05eebede89661660945da1f151959900903b6a",
         "type": "github"
       },
       "original": {
@@ -368,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1730531603,
-        "narHash": "sha256-Dqg6si5CqIzm87sp57j5nTaeBbWhHFaVyG7V6L8k3lY=",
+        "lastModified": 1740828860,
+        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "7ffd9ae656aec493492b44d0ddfb28e79a1ea25d",
+        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
         "type": "github"
       },
       "original": {
@@ -385,33 +399,34 @@
     "org-9-7-15": {
       "flake": false,
       "locked": {
-        "lastModified": 1730506560,
-        "narHash": "sha256-FaVN1RifemYysMKCwZTmLkfE19yUILPG0NBrNKwCbDY=",
-        "ref": "refs/heads/main",
-        "rev": "5e86016cf97d2f97dcf722e7c0733fa35f91a3d5",
-        "revCount": 27939,
-        "type": "git",
-        "url": "https://git.savannah.gnu.org/git/emacs/org-mode.git?tag=release_9.7.15"
+        "lastModified": 1730445956,
+        "narHash": "sha256-mZAypZ8bxWLjnCZX/4XE5Qw2+ieFCyzY/YQnZF1n9+Q=",
+        "owner": "emacs-straight",
+        "repo": "org-mode",
+        "rev": "a1df10f679a72fe75c3d95d1e41b5fdb689fe22e",
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "https://git.savannah.gnu.org/git/emacs/org-mode.git?tag=release_9.7.15"
+        "owner": "emacs-straight",
+        "ref": "release_9.7.15",
+        "repo": "org-mode",
+        "type": "github"
       }
     },
     "org-main": {
       "flake": false,
       "locked": {
-        "lastModified": 1730506560,
-        "narHash": "sha256-FaVN1RifemYysMKCwZTmLkfE19yUILPG0NBrNKwCbDY=",
-        "ref": "refs/heads/main",
-        "rev": "5e86016cf97d2f97dcf722e7c0733fa35f91a3d5",
-        "revCount": 27939,
-        "type": "git",
-        "url": "https://git.savannah.gnu.org/git/emacs/org-mode.git"
+        "lastModified": 1740928457,
+        "narHash": "sha256-hW88dA0F6y4thkWkOuAKi+UmD4e9ICDJTO0HrMc/pXU=",
+        "owner": "emacs-straight",
+        "repo": "org-mode",
+        "rev": "6323accc4860e739f481fd16cfbe8df5e5277458",
+        "type": "github"
       },
       "original": {
-        "type": "git",
-        "url": "https://git.savannah.gnu.org/git/emacs/org-mode.git"
+        "owner": "emacs-straight",
+        "repo": "org-mode",
+        "type": "github"
       }
     },
     "root": {
@@ -455,7 +470,7 @@
     "typst-0-12-0": {
       "flake": false,
       "locked": {
-        "lastModified": 1729288086,
+        "lastModified": 1729288087,
         "narHash": "sha256-ta69kqJM9kyRWJxykXOM5/fP1MTRO0V+ZnFdG0nKCiI=",
         "type": "tarball",
         "url": "https://github.com/typst/typst/releases/download/v0.12.0/typst-x86_64-unknown-linux-musl.tar.xz"

--- a/flake.lock
+++ b/flake.lock
@@ -382,11 +382,11 @@
     },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1740828860,
-        "narHash": "sha256-cjbHI+zUzK5CPsQZqMhE3npTyYFt9tJ3+ohcfaOF/WM=",
+        "lastModified": 1741246872,
+        "narHash": "sha256-Q6pMP4a9ed636qilcYX8XUguvKl/0/LGXhHcRI91p0U=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "303bd8071377433a2d8f76e684ec773d70c5b642",
+        "rev": "10069ef4cf863633f57238f179a0297de84bd8d3",
         "type": "github"
       },
       "original": {
@@ -416,11 +416,11 @@
     "org-main": {
       "flake": false,
       "locked": {
-        "lastModified": 1740928457,
-        "narHash": "sha256-hW88dA0F6y4thkWkOuAKi+UmD4e9ICDJTO0HrMc/pXU=",
+        "lastModified": 1741312429,
+        "narHash": "sha256-3ZAgTGFUqr3NtGZyZVL04Ca1xk5rcvZryIgwI9FBcwI=",
         "owner": "emacs-straight",
         "repo": "org-mode",
-        "rev": "6323accc4860e739f481fd16cfbe8df5e5277458",
+        "rev": "2dc2d3e738a79d9b2c5a780e6c42d9b86549e5d6",
         "type": "github"
       },
       "original": {
@@ -435,8 +435,8 @@
         "nixpkgs": "nixpkgs_2",
         "org-9-7-15": "org-9-7-15",
         "org-main": "org-main",
-        "typst-0-11-0": "typst-0-11-0",
-        "typst-0-12-0": "typst-0-12-0"
+        "typst-0-12-0": "typst-0-12-0",
+        "typst-0-13-0": "typst-0-13-0"
       }
     },
     "systems": {
@@ -454,19 +454,6 @@
         "type": "github"
       }
     },
-    "typst-0-11-0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1710526344,
-        "narHash": "sha256-8ir6DOhUCuL8NiebjnXCyg2zt5ust61sdBl7YAfqTyw=",
-        "type": "tarball",
-        "url": "https://github.com/typst/typst/releases/download/v0.11.0/typst-x86_64-unknown-linux-musl.tar.xz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/typst/typst/releases/download/v0.11.0/typst-x86_64-unknown-linux-musl.tar.xz"
-      }
-    },
     "typst-0-12-0": {
       "flake": false,
       "locked": {
@@ -478,6 +465,19 @@
       "original": {
         "type": "tarball",
         "url": "https://github.com/typst/typst/releases/download/v0.12.0/typst-x86_64-unknown-linux-musl.tar.xz"
+      }
+    },
+    "typst-0-13-0": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1739982711,
+        "narHash": "sha256-tpAtqaY4/zG319en/vbAgMgzz1r02Wh6oNKhjrL5HEk=",
+        "type": "tarball",
+        "url": "https://github.com/typst/typst/releases/download/v0.13.0/typst-x86_64-unknown-linux-musl.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/typst/typst/releases/download/v0.13.0/typst-x86_64-unknown-linux-musl.tar.xz"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -120,6 +120,7 @@
     }:
       pkgs.writeShellScriptBin "test-typst.sh" ''
         set -e
+        export PATH="${pkgs."typst-${versionToKey typst-version}"}/bin/:$PATH"
         # for all org files in test dir
         for file in $(find tests -name "*.org"); do
           # remove extension of file and replace with typ
@@ -132,7 +133,7 @@
 
           echo "Compiling $typ_file"
           # compile the typ file
-          ${pkgs."typst-${versionToKey typst-version}"}/bin/typst c $typ_file
+          sh $typ_file
         done
       '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -112,6 +112,7 @@
     in
       pkgs.writeShellScriptBin "emacs" ''
         export PATH="${typst-bin}/bin/:$PATH"
+        export PATH="${pkgs.pandoc}/bin/:$PATH"
         ${emacs-final}/bin/emacs -q --eval ${pkgs.lib.escapeShellArg load-path} "$@"
       '';
 

--- a/flake.nix
+++ b/flake.nix
@@ -17,12 +17,12 @@
       url = "github:emacs-straight/org-mode";
       flake = false;
     };
-    "typst-0-12-0" = {
-      url = "https://github.com/typst/typst/releases/download/v0.12.0/typst-x86_64-unknown-linux-musl.tar.xz";
+    "typst-0-13-0" = {
+      url = "https://github.com/typst/typst/releases/download/v0.13.0/typst-x86_64-unknown-linux-musl.tar.xz";
       flake = false;
     };
-    "typst-0-11-0" = {
-      url = "https://github.com/typst/typst/releases/download/v0.11.0/typst-x86_64-unknown-linux-musl.tar.xz";
+    "typst-0-12-0" = {
+      url = "https://github.com/typst/typst/releases/download/v0.12.0/typst-x86_64-unknown-linux-musl.tar.xz";
       flake = false;
     };
   };
@@ -53,8 +53,8 @@
       "release-snapshot"
     ];
     typst-versions = [
+      "0.13.0"
       "0.12.0"
-      "0.11.0"
     ];
     buildTypst = {
       pkgs,

--- a/flake.nix
+++ b/flake.nix
@@ -10,11 +10,11 @@
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     nix-emacs-ci.url = "github:purcell/nix-emacs-ci";
     "org-9-7-15" = {
-      url = "git+https://git.savannah.gnu.org/git/emacs/org-mode.git?tag=release_9.7.15";
+      url = "github:emacs-straight/org-mode?ref=release_9.7.15";
       flake = false;
     };
     "org-main" = {
-      url = "git+https://git.savannah.gnu.org/git/emacs/org-mode.git";
+      url = "github:emacs-straight/org-mode";
       flake = false;
     };
     "typst-0-12-0" = {
@@ -83,7 +83,6 @@
           if org-version == "main"
           then org-src.lastModifiedDate
           else org-version;
-        commit = org-src.rev;
 
         src = org-src;
 

--- a/ox-typst.el
+++ b/ox-typst.el
@@ -474,7 +474,7 @@ will result in `ox-typst' to apply the colors to the code block."
     (_ nil)))
 
 (defun org-typst-plain-text (contents _info)
-  (org-typst--escape '("#") contents))
+  (org-typst--escape '("#" "$") contents))
 
 (defun org-typst-planning (_planning _contents _info)
   (message "// todo: org-typst-planning"))

--- a/ox-typst.el
+++ b/ox-typst.el
@@ -403,8 +403,7 @@ will result in `ox-typst' to apply the colors to the code block."
   "#linebreak")
 
 (defun org-typst-link (link contents info)
-  (let ((link-raw (org-typst--as-string (org-element-property :raw-link link)))
-        ;; NOTE: Typst is a bit picky about labels inside headlines. If we point
+  (let (;; NOTE: Typst is a bit picky about labels inside headlines. If we point
         ;; to an element inside a headline, we need to point to the headline
         ;; instead. Most of the time this is what you want, but it might not be
         ;; correct.
@@ -438,13 +437,14 @@ will result in `ox-typst' to apply the colors to the code block."
           (format "#ref(label(%s))" link-path))))
      ;; Other like HTTP (external)
      (t
-      (format "#link(%s)%s"
-              (org-typst--as-string link-raw)
-              (if contents
-                  (format "[%s] #footnote(link(%s))"
-                          (org-trim contents)
-                          link-raw)
-                ""))))))
+      (let ((link-typst (org-typst--as-string (org-element-property :raw-link link))))
+        (format "#link(%s)%s"
+                link-typst
+                (if contents
+                    (format "[%s] #footnote(link(%s))"
+                            (org-trim contents)
+                            link-typst)
+                  "")))))))
 
 (defun org-typst-node-property (_node-property _contents _info)
   (message "// todo: org-typst-node-property"))

--- a/ox-typst.el
+++ b/ox-typst.el
@@ -128,7 +128,7 @@ to consider, and value is a regexp that will be matched against
 link's path.
 
 Note that the support for images is very limited within Typest.  See
-https://typst.app/docs/reference/visualize/image/ supprted types."
+<https://typst.app/docs/reference/visualize/image/> supported types."
   :group 'org-export-typst
   :type '(alist :key-type (string :tag "Type")
                 :value-type (regexp :tag "Path")))
@@ -136,7 +136,7 @@ https://typst.app/docs/reference/visualize/image/ supprted types."
 (defcustom org-typst-from-latex-fragment #'org-typst-from-latex-with-naive
   "Defines the way the Typst transforms LaTeX fragments into Typst code.
 
-If `nil', then the all LaTeX fragment will be ignored. Otherwise, the provided
+If nil, then the all LaTeX fragment will be ignored.  Otherwise, the provided
 function is called with a single argument, the raw LaTeX fragment as a string."
   :type 'function
   :group 'org-export-typst)
@@ -710,7 +710,7 @@ start range of the timestamp is extracted."
               day))))
 
 (defun org-typst-from-latex-with-pandoc (latex-fragment)
-  "Convert a LaTeX fragment into a Typst expression using Pandoc."
+  "Convert a LATEX-FRAGMENT into a Typst expression using Pandoc."
   (with-temp-buffer
     (insert latex-fragment)
     (call-shell-region
@@ -723,14 +723,14 @@ start range of the timestamp is extracted."
      (buffer-substring-no-properties (point-min) (point-max)))))
 
 (defun org-typst-from-latex-with-naive (latex-fragment)
-  "Convert a LaTeX fragment into Typst code.
+  "Convert a LATEX-FRAGMENT into Typst code.
 
 This approach is very naive and assumes that the provided LaTeX fragment has the
-same inner syntax as Typst. For more complex fragments, use a different
+same inner syntax as Typst.  For more complex fragments, use a different
 converter.
 
 The advantage of this convert is the availability in Emacs without additional
-dependencies. Other converts rely on external dependencies."
+dependencies.  Other converts rely on external dependencies."
   (cond
    ((string-match-p "^[ \t]*\$.*\$[ \t]*$" latex-fragment) latex-fragment)
    ((string-match-p "^[ \t]*\\\\(.*\\\\)[ \t]*$" latex-fragment)
@@ -843,7 +843,7 @@ Return PDF file's name."
   "Compile Typst file to PDF.
 
 TYPFILE is the name of the file being compiled.  The Typst command for the
-compilation is controlled by `org-typst-process'.  Output of the compilation 
+compilation is controlled by `org-typst-process'.  Output of the compilation
 process is redirected to \"*Org PDF Typst Output*\" buffer.
 
 Return PDF file name or raise an error if it couldn't be produced."

--- a/ox-typst.el
+++ b/ox-typst.el
@@ -149,6 +149,20 @@ it is used to translate LaTeX environments instead of fragments."
   :type 'function
   :group 'org-export-typst)
 
+(defcustom org-typst-src-apply-theme-color nil
+  "Specify the behavior for applying custom theme colors to src-bocks.
+
+When providing a custom theme through `org-typst-src-themes', the foreground and
+background colors are ignored by Typst.  According to the documentation, the
+user has to apply these colors by them self.  Setting this variable accordingly,
+will result in `ox-typst' to apply the colors to the code block."
+  :type '(choice
+          (const :tag "None" nil)
+          (const :tag "Foreground only" foreground)
+          (const :tag "Background only" background)
+          (const :tag "Both" t))
+  :group 'org-export-typst)
+
 ;; Export
 (org-export-define-backend 'typst
   '((bold . org-typst-bold)
@@ -243,7 +257,6 @@ it is used to translate LaTeX environments instead of fragments."
   (org-typst--raw contents example-block info nil t))
 
 (defun org-typst-export-block (export-block _contents _info)
-  (message "%s" (org-element-property :type export-block))
   (when (member (org-element-property :type export-block) '("TYPST" "TYP"))
     (org-remove-indentation (org-element-property :value export-block))))
 
@@ -586,25 +599,246 @@ it is used to translate LaTeX environments instead of fragments."
      (org-element-property :value latex-fragment))))
 
 ;; Helper
-(defun org-typst--raw (content element info &optional language block)
+(defun org-typst--collect-text-faces (text new-major-mode)
+  "Collect the faces and its position of a TEXT in its NEW-MAJOR-MODE.
+
+The return value is a list which contains the text as lines.  Each line consists
+of one more elements which compose the text.  These elements have the form
+`(START FACE END)'."
+  (with-temp-buffer
+    (funcall new-major-mode)
+    (insert text)
+    (goto-char (point-min))
+    (when (not (equal major-mode new-major-mode))
+      (error "Could not turn on major mode `%s', enabled major mode `%s'" new-major-mode major-mode))
+    (font-lock-ensure)
+    (let ((lines nil)
+          (current-line nil)
+          (line-number 1))
+      (while (not (eobp))
+        (let ((start (point))
+              (face (plist-get (text-properties-at (point)) 'face))
+              (end (goto-char (min (line-end-position)
+                                   (or (next-property-change (point))
+                                       (point-max))))))
+          (push (list start face end) current-line)
+          (when (equal end (line-end-position))
+            (push (seq-reverse current-line) lines)
+            (setq line-number (1+ line-number)
+                  current-line nil)
+            (when (not (eobp))
+              (forward-char)))))
+      lines)))
+
+(defun org-typst--face-get-attr (face attribute)
+  "Return the ATTRIBUTE of the corresponding FACE.
+
+If an attribute is unspecified on and the face inherits from another face, then
+the value of the inherit face is used.  This continues until a face does not
+inherits from another face."
+  (let* ((preferred-value (face-attribute face attribute))
+         (fallback-value (when (equal preferred-value 'unspecified)
+                           (let ((inherit (face-attribute face :inherit)))
+                             (when (and inherit (not (equal inherit 'unspecified)))
+                             (org-typst--face-get-attr inherit attribute))))))
+    (if (equal preferred-value 'unspecified)
+        (if (equal fallback-value 'unspecified)
+            nil
+          fallback-value)
+      preferred-value)))
+
+(defun org-typst--text-and-face-into-typst (text face)
+  "Convert a TEXT with style of FACE into Typst code."
+  (let* ((foreground (org-typst--face-get-attr face :foreground))
+         (underline (org-typst--face-get-attr face :underline))
+         (overline (org-typst--face-get-attr face :overline))
+         (slant (org-typst--face-get-attr face :slant))
+         (weight (org-typst--face-get-attr face :weight))
+         (strike-through (org-typst--face-get-attr face :strike-through))
+         (underline-fn (lambda (content) (if underline (concat "#underline[" content "]" ) content)))
+         (overline-fn (lambda (content) (if overline (concat "#overline["  content "]") content)))
+         (strike-through-fn (lambda (content) (if strike-through (concat "#strike[" content "]") content))))
+    (seq-reduce
+     (lambda (content fn) (funcall fn content))
+     (list underline-fn overline-fn strike-through-fn)
+     (concat
+      "#text("
+      (when foreground (concat "fill: " (org-typst--as-color foreground) ","))
+      (when weight (concat "weight: " (org-typst--as-string weight) ","))
+      (when slant (concat "style: "
+                          (org-typst--as-string
+                           ;; slant can be 'italic, 'oblique, or 'roman
+                           (if (string-equal slant 'roman) "normal"
+                             slant))
+                          ","))
+      (org-typst--as-string text)
+      ")"))))
+
+(defun org-typst--engrave-code (text new-major-mode)
+  "Convert a TEXT with its NEW-MAJOR-MODE into a Typst code."
+  (let* ((lines (seq-map (lambda (elements)
+                           (seq-reduce (lambda (acc element)
+                                         (concat acc
+                                                 (let* ((start (car element))
+                                                        (face (cadr element))
+                                                        (end (caddr element))
+                                                        (text (substring text (1- start) (1- end))))
+                                                   (concat "\n"
+                                                           (if face
+                                                               (concat "[" (org-typst--text-and-face-into-typst text face) "]")
+                                                             (org-typst--as-string text t))))))
+                                       elements
+                                       ""))
+                         (org-typst--collect-text-faces text new-major-mode))))
+    (format "show raw.line: it => { %s }"
+            (apply
+             #'concat
+             (cl-loop for line in (seq-reverse lines)
+                      for line-number from 1
+                      collect (format "\nif it.number == %s { %s }" line-number line))))))
+
+
+(defun org-typst--raw (content element info &optional raw-language block)
   "Wrap CONTENT in a raw Typst block.
 
 If BLOCK is not nil, then content will additionally wrapped in a figure with the
 arguments of ELEMENT and INFO.
 
-LANGUAGE is the language of the code block and will be used as the `language`
-argument in Typst."
+RAW-LANGUAGE is the language of the code block and will be used as the
+`language' argument in Typst."
   (when content
-    (let ((raw (format "#raw(block: %s, %s%s)"
-                       (if block "true" "false")
-                       (if language (concat "lang: "
-                                            (org-typst--language language)
-                                            ", ")
-                         "")
-                       (org-typst--as-string content))))
-      (if block
-          (org-typst--figure raw element info)
-        raw))))
+    (let* ((attributes (org-export-read-attribute :attr_typst element))
+           (language (when raw-language (org-typst--language raw-language)))
+           ;; TODO: maybe read the tab-size set by the mapped mode in Org?
+           (tab-size (org-export-read-attribute :attr_typst element :tab-size))
+           (engrave (org-export-read-attribute :attr_typst element :engrave))
+           (theme (org-typst--attribute-file :theme attributes))
+           (syntax (org-typst--attribute-file :syntaxes attributes))
+           (theme-settings (when (and theme (not (equal theme 'none)))
+                             (org-typst--xml-theme-global-settings (org-typst--xml-read-plist theme))))
+           (raw (format "#raw(block: %s, %s)"
+                        (if block "true" "false")
+                        (concat
+                         (when tab-size (concat "tab_size: " tab-size ", "))
+                         (when language (concat "lang: "
+                                                (org-typst--as-string language)
+                                                ", "))
+                         (when theme (concat "theme: " (org-typst--as-typst-value theme) ","))
+                         (when syntax (concat "syntaxes: " (org-typst--as-typst-value syntax) ","))
+                         (org-typst--as-string content)))))
+      (if (and theme-settings org-typst-src-apply-theme-color)
+          (let* ((fg (org-typst--xml-dict-get theme-settings "foreground"))
+                 (bg (org-typst--xml-dict-get theme-settings "background"))
+                 (bg-fmt (when bg (format "#block(fill: %s, inset: 4pt)" (org-typst--as-color (org-typst--xml-as-string bg)))))
+                 (fg-fmt (when fg (format "#text(fill: %s)" (org-typst--as-color (org-typst--xml-as-string fg))))))
+            (when fg (setq raw (concat fg-fmt "[" raw "]")))
+            (when bg (setq raw (concat bg-fmt "[" raw "]")))))
+      (let* ((major-mode-of-language (org-src-get-lang-mode language))
+             (actual-code (if block
+                              (org-typst--figure raw element info)
+                            raw)))
+        (if engrave
+            (if (not major-mode-of-language)
+                (error "Language `%s` does not map to any major mode, configure `org-src-lang-modes' accordingly" language)
+              (format "#{ %s \n[%s] }" (org-typst--engrave-code content major-mode-of-language) actual-code))
+          actual-code)))))
+
+(defun org-typst--as-color (color)
+  "Convert Emacs COLOR into Typst color."
+
+  (seq-let (red green blue) (tty-color-standard-values color)
+    (format "rgb(%d, %d, %d)"
+            (/ red 256)
+            (/ green 256)
+            (/ blue 256))))
+
+(defun org-typst--plist-find (plist pred)
+  "Find a single element in PLIST which matches PRED.
+
+PRED is a function which takes the plist key and value as arguments.  If PRED
+returns t, then the key value pair is returned as a list."
+  (let ((returns nil))
+    (while (and (not returns) plist)
+      (when (funcall pred (car plist) (cadr plist))
+        (setq returns (list (car plist) (cadr plist))))
+      (setq plist (cddr plist)))
+    returns))
+
+(defun org-typst--xml-type? (xml type)
+  "Check that XML is of TYPE."
+  (equal (car xml) type))
+
+(defun org-typst--xml-dict-get (xml key)
+  "Return the KEY of an XML dictionary.
+
+The XML must be of type `dict', otherwise an error is signaled.  When the key is
+found, then the value is returned.  Otherwise, `nil' is returned."
+  (if (not (org-typst--xml-type? xml 'dict))
+      (error "Element not an XML dict")
+    (cadr (org-typst--plist-find (cddr xml) (lambda (k _)
+                                              (and (equal (car k) 'key)
+                                                   (equal (caddr k) key)))))))
+
+(defun org-typst--xml-as-string (xml)
+  "Get value for string type of XML."
+  (if (not (org-typst--xml-type? xml 'string))
+      (error "Element not an XML string")
+    (caddr xml)))
+
+(defun org-typst--xml-array-filter-type (xml type)
+  "Filter an XML array for TYPE.
+
+The resulting list only contains elements which are of type TYPE."
+  (if (not (org-typst--xml-type? xml 'array))
+      (error "Element not an XML array")
+    (seq-filter
+     (lambda (elm) (and (listp elm) (equal (car elm) type))) (cddr xml))))
+
+(defun org-typst--xml-theme-global-settings (dict)
+  "Get the global settings part of a Sublime theme stored in DICT."
+  (if (not (org-typst--xml-type? dict 'dict))
+      (error "Element not an XML dict")
+    (let* ((dicts (seq-filter (lambda (elm)
+                                (and (org-typst--xml-type? elm 'dict)
+                                     (not (org-typst--xml-dict-get elm "scope"))))
+                              (org-typst--xml-array-filter-type (org-typst--xml-dict-get dict "settings") 'dict))))
+      (if (equal (length dicts) 1)
+          (org-typst--xml-dict-get (car dicts) "settings")
+        (error "Theme was more than one global config")))))
+
+(defun org-typst--xml-read-plist (file)
+  "Parse XML FILE which must be a valid plist structure.
+
+Sublime use the plist structure to store their themes."
+  (let* ((xml (with-temp-buffer
+                (insert-file-contents file)
+                (libxml-parse-html-region))))
+    (caddr (caddr (caddr
+                   (pcase (car xml)
+                     ('html xml)
+                     ('top (car (seq-filter (lambda (elm)
+                                              (and (listp elm)
+                                                   (equal (car elm) 'html)))
+                                            xml)))))))))
+
+(defun org-typst--as-typst-value (value)
+  "Convert the Elisp VALUE into a valid Typst value."
+  (cond
+   ((equal 'none value) "none")
+   ((stringp value) (org-typst--as-string value))))
+
+(defun org-typst--attribute-file (key attributes)
+  "Interpret the element KEY of the list ATTRIBUTES as a file path.
+
+If the value is empty, then the string \"none\" is returned.  Otherwise, the
+string with the relative file path.  Notice that Typst only supports relative
+file paths, to the `TYPST_ROOT'.  Absolute paths are not supported and these
+files paths must be in the same directory as Org file or in a sub directory."
+  (when (plist-member attributes key)
+    (let ((file (plist-get attributes key)))
+      (if (string-empty-p file)
+          'none
+        file))))
 
 (defun org-typst--label (content item info)
   "Wrap ITEM and its CONTENT in a Typst label.
@@ -657,14 +891,21 @@ The resulting string will contain a \\u{XXXX} for every char specified in CHARS.
               chars
               string))
 
-(defun org-typst--as-string (string)
+(defun org-typst--as-string (string &optional no-trim)
   "Construct Typst string with content STRING.
 
-The STRING will escape every occurrence of `\"'."
+The STRING will escape every occurrence of `\"'.  Normally the STRING is
+trimmed, but can be disabled with NO-TRIM."
   (when string
-    (concat "\""
-            (org-trim (org-typst--escape '("\"") string))
-            "\"")))
+    (let* ((actual-string (cond ((stringp string) string)
+                                ((symbolp string) (symbol-name string))
+                                (t (error "Unsupported type %s of %s" (type-of string) string))))
+           (escaped (org-typst--escape '("\"") actual-string)))
+      (concat "\""
+              (if no-trim
+                  escaped
+                (org-trim escaped))
+              "\""))))
 
 (defun org-typst--language (language)
   "Map Org LANGUAGE to Typst language for source blocks.
@@ -672,11 +913,10 @@ The STRING will escape every occurrence of `\"'."
 The user can define the mapping `org-typst-language-mapping', to rename the
 languages.  If the language is not defined in the mapping, then it is
 returned.  Otherwise, the mapped language is returned."
-  (org-typst--as-string
-   (or
-    (cdr (seq-find (lambda (pl) (string-equal (car pl) language))
-                   org-typst-language-mapping))
-    language)))
+  (or
+   (cdr (seq-find (lambda (pl) (string-equal (car pl) language))
+                  org-typst-language-mapping))
+   language))
 
 (defun org-typst--timestamp (timestamp end)
   "Construct Typst timestamp from TIMESTAMP.

--- a/ox-typst.el
+++ b/ox-typst.el
@@ -1,6 +1,6 @@
 ;;; ox-typst.el --- Typst Back-End for Org Export Engine -*- lexical-binding: t; -*-
 
-;; Copyright (C) 2023-2024 Jonas Meurer
+;; Copyright (C) 2023-2025 Jonas Meurer
 
 ;; Author: Jonas Meurer
 ;; Keywords: text, wp, org, typst

--- a/ox-typst.el
+++ b/ox-typst.el
@@ -163,6 +163,9 @@ will result in `ox-typst' to apply the colors to the code block."
           (const :tag "Both" t))
   :group 'org-export-typst)
 
+(defvar org-typst--file-paths nil
+  "List of file paths used by the Org file.")
+
 ;; Export
 (org-export-define-backend 'typst
   '((bold . org-typst-bold)
@@ -417,7 +420,7 @@ will result in `ox-typst' to apply the colors to the code block."
      ((org-export-inline-image-p link org-typst-inline-image-rules)
       (org-typst--figure (format
                           "#image(%s)"
-                          (org-typst--as-string
+                          (org-typst--as-typst-path
                            (org-element-property
                             :path (org-export-link-localise link))))
                          link
@@ -554,6 +557,9 @@ will result in `ox-typst' to apply the colors to the code block."
                  (plist-get info :email)))
         (toc (plist-get info :with-toc)))
     (concat
+     (format "#let _ = ```typ
+exec %s
+⁠```\n" (org-typst--generate-command (plist-get info :input-file) t))
      (when (or (car title) author)
        (concat
         "#set document("
@@ -712,8 +718,8 @@ RAW-LANGUAGE is the language of the code block and will be used as the
            ;; TODO: maybe read the tab-size set by the mapped mode in Org?
            (tab-size (org-export-read-attribute :attr_typst element :tab-size))
            (engrave (org-export-read-attribute :attr_typst element :engrave))
-           (theme (org-typst--attribute-file :theme attributes))
-           (syntax (org-typst--attribute-file :syntaxes attributes))
+           (theme (org-typst--attribute-value :theme attributes))
+           (syntax (org-typst--attribute-value :syntaxes attributes))
            (theme-settings (when (and theme (not (equal theme 'none)))
                              (org-typst--xml-theme-global-settings (org-typst--xml-read-plist theme))))
            (raw (format "#raw(block: %s, %s)"
@@ -723,8 +729,8 @@ RAW-LANGUAGE is the language of the code block and will be used as the
                          (when language (concat "lang: "
                                                 (org-typst--as-string language)
                                                 ", "))
-                         (when theme (concat "theme: " (org-typst--as-typst-value theme) ","))
-                         (when syntax (concat "syntaxes: " (org-typst--as-typst-value syntax) ","))
+                         (when theme (concat "theme: " (org-typst--as-typst-path theme) ","))
+                         (when syntax (concat "syntaxes: " (org-typst--as-typst-path syntax) ","))
                          (org-typst--as-string content)))))
       (if (and theme-settings org-typst-src-apply-theme-color)
           (let* ((fg (org-typst--xml-dict-get theme-settings "foreground"))
@@ -821,24 +827,29 @@ Sublime use the plist structure to store their themes."
                                                    (equal (car elm) 'html)))
                                             xml)))))))))
 
-(defun org-typst--as-typst-value (value)
-  "Convert the Elisp VALUE into a valid Typst value."
-  (cond
-   ((equal 'none value) "none")
-   ((stringp value) (org-typst--as-string value))))
-
-(defun org-typst--attribute-file (key attributes)
-  "Interpret the element KEY of the list ATTRIBUTES as a file path.
+(defun org-typst--attribute-value (key attributes)
+  "Return value of KEY in ATTRIBUTES.
 
 If the value is empty, then the string \"none\" is returned.  Otherwise, the
-string with the relative file path.  Notice that Typst only supports relative
-file paths, to the `TYPST_ROOT'.  Absolute paths are not supported and these
-files paths must be in the same directory as Org file or in a sub directory."
+value."
   (when (plist-member attributes key)
-    (let ((file (plist-get attributes key)))
-      (if (string-empty-p file)
+    (let ((value (plist-get attributes key)))
+      (if (string-empty-p value)
           'none
-        file))))
+        value))))
+
+(defun org-typst--as-typst-path (file-path)
+  "Convert existing FILE-PATH into Typst placeholder.
+
+File paths are provided through the `--inputs' argument when compiling.  The
+returned Typst expression acts as a placeholder and will be resolved by Typst
+during compilation.  See `org-typst--common-paths' for the further details."
+  (when file-path
+    (if (equal file-path 'none)
+        "none"
+      (let ((idx (length org-typst--file-paths)))
+        (push (list (format "file-%s" idx) file-path) org-typst--file-paths)
+        (format "sys.inputs.file-%s" idx)))))
 
 (defun org-typst--label (content item info)
   "Wrap ITEM and its CONTENT in a Typst label.
@@ -949,6 +960,31 @@ start range of the timestamp is extracted."
               month
               day))))
 
+(defun org-typst--common-paths (dir)
+  "Calculate the common prefix of all used files starting from DIR.
+
+The common prefix and a list of all files with relative paths (to the prefix) is
+returned.  Files which are used by Org might be located outside of the project
+root.  We have to find the longest or common prefix of all use files.  This
+prefix will become the new project root allowing all files to be found by Typst."
+  (let* ((absolute-paths (seq-map (lambda (tuple)
+                                    (seq-let (key path) tuple
+                                      (list key (expand-file-name path))))
+                                  org-typst--file-paths))
+         (longest-prefix (seq-reduce
+                          (lambda (prefix tuple)
+                            (seq-let (_ path) tuple
+                              (fill-common-string-prefix prefix path)))
+                          absolute-paths
+                          (file-name-as-directory (expand-file-name dir)))))
+
+    (list
+     longest-prefix
+     (seq-map (lambda (tuple)
+                (seq-let (key path) tuple
+                  (list key (file-relative-name path longest-prefix))))
+              absolute-paths))))
+
 (defun org-typst-from-latex-with-pandoc (latex-fragment)
   "Convert a LATEX-FRAGMENT into a Typst expression using Pandoc."
   (with-temp-buffer
@@ -1014,6 +1050,7 @@ Export is done in a buffer named \"*Org Typst Export*\", which will be displayed
 when `org-export-show-temporary-export-buffer' is non-nil.  The resulting buffer
 will use the major mode specified by `org-typst-export-buffer-major-mode'."
   (interactive)
+  (setq org-typst--file-paths nil)
   (org-export-to-buffer 'typst org-typst-export-buffer-name
                         async subtreep visible-only body-only ext-plist
                         (when org-typst-export-buffer-major-mode
@@ -1045,6 +1082,7 @@ BODY-ONLY currently has no effect.  The entire buffer is always exported.
 EXT-PLIST, when provided, is a property list with external parameters overriding
 Org default settings, but still inferior to file-local settings."
   (interactive)
+  (setq org-typst--file-paths nil)
   (let ((outfile (org-export-output-file-name ".typ" subtreep)))
     (org-export-to-file 'typst outfile
                         async subtreep visible-only body-only ext-plist)))
@@ -1074,27 +1112,50 @@ Org default settings, but still inferior to file-local settings.
 
 Return PDF file's name."
   (interactive)
+  (setq org-typst--file-paths nil)
   (let ((outfile (org-export-output-file-name ".typ" subtreep)))
     (org-export-to-file 'typst outfile
                         async subtreep visible-only body-only ext-plist
                         #'org-typst-compile)))
 
-(defun org-typst-compile (typfile)
-  "Compile Typst file to PDF.
+(defun org-typst--generate-command (typst-file &optional no-input)
+  "Create compile command for TYPST-FILE."
+  (let* ((typst-file-absolute (expand-file-name typst-file))
+         (typst-file-dir (file-name-parent-directory typst-file-absolute))
+         (prefix-files (org-typst--common-paths typst-file-dir))
+         (typst-root-new (car prefix-files))
+         (relative-position-to-root (file-relative-name
+                                     typst-root-new typst-file-dir)))
+    (concat (format org-typst-process (if no-input "$0" typst-file-absolute))
+            (format " --root \"%s\""
+                    (if no-input
+                        (format "$(readlink -f \"$0\" | xargs dirname)/%s"
+                                relative-position-to-root)
+                      typst-root-new))
+            (apply #'concat
+                   (seq-map
+                    (lambda (tuple)
+                      (seq-let (key path) tuple
+                        (concat " --input "
+                                (shell-quote-argument
+                                 (format "%s=/%s" key path)))))
+                    (cadr prefix-files))))))
 
-TYPFILE is the name of the file being compiled.  The Typst command for the
+(defun org-typst-compile (typst-file)
+  "Compile TYPST-FILE into PDF.
+
+TYPST-FILE is the name of the file being compiled.  The Typst command for the
 compilation is controlled by `org-typst-process'.  Output of the compilation
 process is redirected to \"*Org PDF Typst Output*\" buffer.
 
 Return PDF file name or raise an error if it couldn't be produced."
   (let* ((log-buf-name "*Org PDF Typst Output*")
          (log-buf (get-buffer-create log-buf-name))
-         (process (format org-typst-process typfile))
+         (process (org-typst--generate-command typst-file))
          outfile)
     (with-current-buffer log-buf
       (erase-buffer))
-
-    (setq outfile (org-compile-file typfile
+    (setq outfile (org-compile-file (expand-file-name typst-file)
                                     (list process)
                                     "pdf"
                                     (format "See %S for details" log-buf-name)

--- a/tests/begin/center.typ
+++ b/tests/begin/center.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/begin/export.typ
+++ b/tests/begin/export.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/begin/quote.typ
+++ b/tests/begin/quote.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/begin/verse.typ
+++ b/tests/begin/verse.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/black.png
+++ b/tests/black.png
@@ -1,0 +1,1 @@
+figure/black.png

--- a/tests/clock/item.typ
+++ b/tests/clock/item.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/clock/schedule.typ
+++ b/tests/clock/schedule.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/clock/table.typ
+++ b/tests/clock/table.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/code/block.typ
+++ b/tests/code/block.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/code/different-theme-color.xml
+++ b/tests/code/different-theme-color.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple Computer//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>name</key>
+    <string>Example Color Scheme</string>
+    <key>settings</key>
+    <array>
+        <!-- Global settings -->
+        <dict>
+            <key>settings</key>
+            <dict>
+                <key>background</key>
+                <string>#222222</string>
+                <key>foreground</key>
+                <string>#ff0095</string>
+            </dict>
+        </dict>
+        <!-- Scope styles -->
+        <dict>
+            <key>name</key>
+            <string>Keyword</string>
+            <key>scope</key>
+            <string>keyword.control</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#161ae0</string>
+            </dict>
+        </dict>
+        <dict>
+            <key>name</key>
+            <string>Constants</string>
+            <key>scope</key>
+            <string>constant.language</string>
+            <key>settings</key>
+            <dict>
+                <key>foreground</key>
+                <string>#00ffb7</string>
+            </dict>
+        </dict>
+    </array>
+</dict>

--- a/tests/code/different-theme-syntax.yml
+++ b/tests/code/different-theme-syntax.yml
@@ -1,0 +1,10 @@
+%YAML 1.2
+---
+name: C
+file_extensions: [cool]
+scope: source.cool
+
+contexts:
+  main:
+    - match: \b(if|else)\b
+      scope: keyword.control.cool

--- a/tests/code/different-theme.org
+++ b/tests/code/different-theme.org
@@ -1,0 +1,49 @@
+* Override Listing Theme
+** Default Without Changes
+#+BEGIN_SRC c
+  if (true) {} else {}
+#+END_SRC
+
+** Mapping (elips -> lisp)
+#+BEGIN_SRC elisp
+  (error "hmm")
+#+END_SRC
+
+** Custom Theme And Syntax
+
+- `if` and else `else` should be highlighted in blue (color of the custom theme).
+
+# Do not use hypens here, whitespaces are detected correctly, except for trainling one.
+#+ATTR_TYPST: :theme different-theme-color.xml :syntaxes different-theme-syntax.yml
+#+BEGIN_SRC cool
+  if (true) {} else {}
+#+END_SRC
+
+** Custom Theme
+
+- `if` and else `else` should be highlighted in blue (color of the custom theme).
+- `true` should be highlighted in cyan (color of the custom theme).
+
+# Do not use hypens here, whitespaces are detected correctly, except for trainling one.
+#+ATTR_TYPST: :theme different-theme-color.xml
+#+BEGIN_SRC c
+  if (true) {} else {}
+#+END_SRC
+
+** Custom Syntax File
+
+- `if` and else `else` should be highlighted in red (color of built-in theme).
+
+# Do not use hypens here, whitespaces are detected correctly, except for trainling one.
+#+ATTR_TYPST: :syntaxes different-theme-syntax.yml
+#+BEGIN_SRC cool
+  if (true) {} else {}
+#+END_SRC
+
+
+** Disable Syntax Highlighting
+
+#+ATTR_TYPST: :theme ""
+#+BEGIN_SRC c
+  if (true) {} else {}
+#+END_SRC

--- a/tests/code/different-theme.typ
+++ b/tests/code/different-theme.typ
@@ -1,0 +1,22 @@
+#set text(lang: "en")
+#outline()
+#set heading(numbering: "1.")
+#heading(level: 1)[Override Listing Theme] #label("org0000018")
+#heading(level: 2)[Default Without Changes] #label("org0000001")
+#figure([#raw(block: true, lang: "c", "if (true) {} else {}")]) #label("org0000000")
+#heading(level: 2)[Mapping (elips -> lisp)] #label("org0000005")
+#figure([#raw(block: true, lang: "lisp", "(error \u{22}hmm\u{22})")]) #label("org0000004")
+#heading(level: 2)[Custom Theme And Syntax] #label("org0000009")
+#list(list.item[`if` and else `else` should be highlighted in blue (color of the custom theme).])
+
+#figure([#raw(block: true, lang: "cool", theme: "different-theme-color.xml",syntaxes: "different-theme-syntax.yml","if (true) {} else {}")]) #label("org0000008")
+#heading(level: 2)[Custom Theme] #label("org000000d")
+#list(list.item[`if` and else `else` should be highlighted in blue (color of the custom theme).])#list(list.item[`true` should be highlighted in cyan (color of the custom theme).])
+
+#figure([#raw(block: true, lang: "c", theme: "different-theme-color.xml","if (true) {} else {}")]) #label("org000000c")
+#heading(level: 2)[Custom Syntax File] #label("org0000011")
+#list(list.item[`if` and else `else` should be highlighted in red (color of built-in theme).])
+
+#figure([#raw(block: true, lang: "cool", syntaxes: "different-theme-syntax.yml","if (true) {} else {}")]) #label("org0000010")
+#heading(level: 2)[Disable Syntax Highlighting] #label("org0000015")
+#figure([#raw(block: true, lang: "c", theme: none,"if (true) {} else {}")]) #label("org0000014")

--- a/tests/code/different-theme.typ
+++ b/tests/code/different-theme.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-3\=/different-theme-syntax.yml --input file-2\=/different-theme-color.xml --input file-1\=/different-theme-syntax.yml --input file-0\=/different-theme-color.xml
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")
@@ -9,14 +12,14 @@
 #heading(level: 2)[Custom Theme And Syntax] #label("org0000009")
 #list(list.item[`if` and else `else` should be highlighted in blue (color of the custom theme).])
 
-#figure([#raw(block: true, lang: "cool", theme: "different-theme-color.xml",syntaxes: "different-theme-syntax.yml","if (true) {} else {}")]) #label("org0000008")
+#figure([#raw(block: true, lang: "cool", theme: sys.inputs.file-0,syntaxes: sys.inputs.file-1,"if (true) {} else {}")]) #label("org0000008")
 #heading(level: 2)[Custom Theme] #label("org000000d")
 #list(list.item[`if` and else `else` should be highlighted in blue (color of the custom theme).])#list(list.item[`true` should be highlighted in cyan (color of the custom theme).])
 
-#figure([#raw(block: true, lang: "c", theme: "different-theme-color.xml","if (true) {} else {}")]) #label("org000000c")
+#figure([#raw(block: true, lang: "c", theme: sys.inputs.file-2,"if (true) {} else {}")]) #label("org000000c")
 #heading(level: 2)[Custom Syntax File] #label("org0000011")
 #list(list.item[`if` and else `else` should be highlighted in red (color of built-in theme).])
 
-#figure([#raw(block: true, lang: "cool", syntaxes: "different-theme-syntax.yml","if (true) {} else {}")]) #label("org0000010")
+#figure([#raw(block: true, lang: "cool", syntaxes: sys.inputs.file-3,"if (true) {} else {}")]) #label("org0000010")
 #heading(level: 2)[Disable Syntax Highlighting] #label("org0000015")
 #figure([#raw(block: true, lang: "c", theme: none,"if (true) {} else {}")]) #label("org0000014")

--- a/tests/code/engrave-with-emacs.org
+++ b/tests/code/engrave-with-emacs.org
@@ -1,0 +1,6 @@
+* Emacs Syntax Highlighting
+
+#+ATTR_TYPST: :engrave t
+#+BEGIN_SRC sh
+  echo hi
+#+END_SRC

--- a/tests/code/engrave-with-emacs.typ
+++ b/tests/code/engrave-with-emacs.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/code/engrave-with-emacs.typ
+++ b/tests/code/engrave-with-emacs.typ
@@ -1,0 +1,9 @@
+#set text(lang: "en")
+#outline()
+#set heading(numbering: "1.")
+#heading(level: 1)[Emacs Syntax Highlighting] #label("org0000001")
+#{ show raw.line: it => { 
+if it.number == 1 { 
+[#text(fill: rgb(255, 192, 203),weight: "bold","echo")]
+" hi" } } 
+[#figure([#raw(block: true, lang: "sh", "echo hi")]) #label("org0000000")] }

--- a/tests/code/inline-block.typ
+++ b/tests/code/inline-block.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/code/inline.typ
+++ b/tests/code/inline.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/code/theme-foreground-background.org
+++ b/tests/code/theme-foreground-background.org
@@ -1,0 +1,14 @@
+#+BIND: org-typst-src-apply-theme-color t
+
+* Theme With Foreground And Background
+
+This theme has a foreground and background specified. However, Typst does not
+apply these colors by default.
+
+- background should be dark
+- braces (all non keywords or constants) should be pink
+
+#+ATTR_TYPST: :theme different-theme-color.xml
+#+BEGIN_SRC c
+  if (true) {} else {}
+#+END_SRC

--- a/tests/code/theme-foreground-background.typ
+++ b/tests/code/theme-foreground-background.typ
@@ -1,0 +1,10 @@
+#set text(lang: "en")
+#outline()
+#set heading(numbering: "1.")
+#heading(level: 1)[Theme With Foreground And Background] #label("org0000001")
+This theme has a foreground and background specified. However, Typst does not
+apply these colors by default.
+
+#list(list.item[background should be dark])#list(list.item[braces (all non keywords or constants) should be pink])
+
+#figure([#block(fill: rgb(34, 34, 34), inset: 4pt)[#text(fill: rgb(255, 0, 149))[#raw(block: true, lang: "c", theme: "different-theme-color.xml","if (true) {} else {}")]]]) #label("org0000000")

--- a/tests/code/theme-foreground-background.typ
+++ b/tests/code/theme-foreground-background.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-0\=/different-theme-color.xml
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")
@@ -7,4 +10,4 @@ apply these colors by default.
 
 #list(list.item[background should be dark])#list(list.item[braces (all non keywords or constants) should be pink])
 
-#figure([#block(fill: rgb(34, 34, 34), inset: 4pt)[#text(fill: rgb(255, 0, 149))[#raw(block: true, lang: "c", theme: "different-theme-color.xml","if (true) {} else {}")]]]) #label("org0000000")
+#figure([#block(fill: rgb(34, 34, 34), inset: 4pt)[#text(fill: rgb(255, 0, 149))[#raw(block: true, lang: "c", theme: sys.inputs.file-0,"if (true) {} else {}")]]]) #label("org0000000")

--- a/tests/etc/entities.typ
+++ b/tests/etc/entities.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/etc/export-snippet.typ
+++ b/tests/etc/export-snippet.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/etc/fixed.typ
+++ b/tests/etc/fixed.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/etc/heading.typ
+++ b/tests/etc/heading.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/etc/include.typ
+++ b/tests/etc/include.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/etc/inlinetask.typ
+++ b/tests/etc/inlinetask.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/etc/meta-informatation.typ
+++ b/tests/etc/meta-informatation.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set document(title: "My Cool Typst", author: "Me You")
 #set text(lang: "en")
 #outline()

--- a/tests/etc/modus-theme/theme.typ
+++ b/tests/etc/modus-theme/theme.typ
@@ -27,7 +27,6 @@
 #show heading.where(level: 3): set text(modus-themes-color-mild, weight: 700, size: 1.15em)
 
 #show outline: it => {text(modus-themes-color-baselinkfg, it)}
-#show outline: set outline(fill: none)
 #show outline.entry: it => [ #h((it.level - 1) * 1em) #it #v(0.1em, weak: true)]
 
 #show terms: it => block(above: 1.5em, it)

--- a/tests/etc/theme.typ
+++ b/tests/etc/theme.typ
@@ -30,7 +30,6 @@
 #show heading.where(level: 3): set text(modus-themes-color-mild, weight: 700, size: 1.15em)
 
 #show outline: it => {text(modus-themes-color-baselinkfg, it)}
-#show outline: set outline(fill: none)
 #show outline.entry: it => [ #h((it.level - 1) * 1em) #it #v(0.1em, weak: true)]
 
 #show terms: it => block(above: 1.5em, it)

--- a/tests/etc/theme.typ
+++ b/tests/etc/theme.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/figure/figure.typ
+++ b/tests/figure/figure.typ
@@ -1,7 +1,10 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-0\=/black.png
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Figure] #label("org0000001")
 Now lets insert a black rectangle.
 
-#figure([#image("./black.png")], caption: [Wow look at this black rectangle. This is another caption for the same black rectangle.]) #label("org0000000")
+#figure([#image(sys.inputs.file-0)], caption: [Wow look at this black rectangle. This is another caption for the same black rectangle.]) #label("org0000000")

--- a/tests/figure/image-outside.org
+++ b/tests/figure/image-outside.org
@@ -1,0 +1,7 @@
+* Image Outside of Typst Root
+
+Normally Typst only understands file which are relative to the project root
+(called TYPST_ROOT).
+
+[[file:../black.png]]
+

--- a/tests/figure/image-outside.typ
+++ b/tests/figure/image-outside.typ
@@ -1,0 +1,11 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/../" --input file-0\=/black.png
+⁠```
+#set text(lang: "en")
+#outline()
+#set heading(numbering: "1.")
+#heading(level: 1)[Image Outside of Typst Root] #label("org0000001")
+Normally Typst only understands file which are relative to the project root
+(called TYPST#sub[ROOT]).
+
+#figure([#image(sys.inputs.file-0)]) #label("org0000000")

--- a/tests/figure/image-remote.org
+++ b/tests/figure/image-remote.org
@@ -1,9 +1,10 @@
 * Remote Image
 
-One image should not be inlined, since Typst does not understand it. The other
-should be inlinded.
+One image should not be inlined, since Typst does not understand the file
+ending. The other should be inlined.
 
 ** Not Included
-[[file:///./black.unknown]]
+[[file:black.unknown]]
+
 ** Included
-[[file:///./black.png]]
+[[file:black.png]]

--- a/tests/figure/image-remote.typ
+++ b/tests/figure/image-remote.typ
@@ -1,10 +1,13 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-0\=/black.png
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Remote Image] #label("org0000007")
-One image should not be inlined, since Typst does not understand it. The other
-should be inlinded.
+One image should not be inlined, since Typst does not understand the file
+ending. The other should be inlined.
 #heading(level: 2)[Not Included] #label("org0000000")
-#link("\u{22}file:///./black.unknown\u{22}")
+#link("file:black.unknown")
 #heading(level: 2)[Included] #label("org0000004")
-#figure([#image("/./black.png")]) #label("org0000003")
+#figure([#image(sys.inputs.file-0)]) #label("org0000003")

--- a/tests/issues/21.org
+++ b/tests/issues/21.org
@@ -1,0 +1,5 @@
+* Dollar Is Not Escaped
+
+Some inline math $x \neq y$.
+
+Some dollar sign $.

--- a/tests/issues/21.org
+++ b/tests/issues/21.org
@@ -1,5 +1,9 @@
 * Dollar Is Not Escaped
 
-Some inline math $x \neq y$.
+Some inline math $x != y$.
 
 Some dollar sign $.
+
+** What about some $ in the Title
+
+** Nice formula in the title $x=1$

--- a/tests/issues/21.typ
+++ b/tests/issues/21.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/issues/21.typ
+++ b/tests/issues/21.typ
@@ -1,7 +1,10 @@
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")
-#heading(level: 1)[Dollar Is Not Escaped] #label("org0000000")
-Some inline math $x \neq y$.
+#heading(level: 1)[Dollar Is Not Escaped] #label("org0000006")
+Some inline math $x != y$.
 
 Some dollar sign \u{24}.
+#heading(level: 2)[What about some \u{24} in the Title] #label("org0000000")
+
+#heading(level: 2)[Nice formula in the title $x=1$] #label("org0000003")

--- a/tests/issues/21.typ
+++ b/tests/issues/21.typ
@@ -1,0 +1,7 @@
+#set text(lang: "en")
+#outline()
+#set heading(numbering: "1.")
+#heading(level: 1)[Dollar Is Not Escaped] #label("org0000000")
+Some inline math $x \neq y$.
+
+Some dollar sign \u{24}.

--- a/tests/link/block.typ
+++ b/tests/link/block.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/link/cite-multiple.typ
+++ b/tests/link/cite-multiple.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/link/cite.typ
+++ b/tests/link/cite.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/link/file.typ
+++ b/tests/link/file.typ
@@ -2,4 +2,4 @@
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[File Links] #label("org0000000")
-The bibliography is #link("\u{22}./cite.typ\u{22}"), this shouldn't be treated as an image.
+The bibliography is #link("./cite.typ"), this shouldn't be treated as an image.

--- a/tests/link/file.typ
+++ b/tests/link/file.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/link/footnote.typ
+++ b/tests/link/footnote.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/link/headline.typ
+++ b/tests/link/headline.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/link/link-external.org
+++ b/tests/link/link-external.org
@@ -1,3 +1,5 @@
 * Link
 
 Maybe found here [[http://google.com][Google]] :)
+
+Or we put a link here https://google.com.

--- a/tests/link/link-external.typ
+++ b/tests/link/link-external.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/link/link-external.typ
+++ b/tests/link/link-external.typ
@@ -2,4 +2,6 @@
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Link] #label("org0000000")
-Maybe found here #link("\u{22}http://google.com\u{22}")[Google] #footnote(link("http://google.com")) :)
+Maybe found here #link("http://google.com")[Google] #footnote(link("http://google.com")) :)
+
+Or we put a link here #link("https://google.com").

--- a/tests/link/link-internal.typ
+++ b/tests/link/link-internal.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/link/property.typ
+++ b/tests/link/property.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/link/radio.typ
+++ b/tests/link/radio.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/list/checkbox.typ
+++ b/tests/list/checkbox.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/list/description.typ
+++ b/tests/list/description.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/list/enumerated.typ
+++ b/tests/list/enumerated.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/list/plain.typ
+++ b/tests/list/plain.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/math/latex-naive-export.org
+++ b/tests/math/latex-naive-export.org
@@ -1,0 +1,12 @@
+#+BIND: org-typst-from-latex-fragment org-typst-from-latex-with-naive
+#+BIND: org-typst-from-latex-environment org-typst-from-latex-with-naive
+
+* Math (naive)
+
+\begin{equation}                        % arbitrary environments,
+x=\sqrt{b}                              % even tables, figures, etc
+\end{equation}
+
+This is inline Math: $a^2=b$. The following two statements are not inlined.
+
+\( a + b \) \[ a=-2 \]

--- a/tests/math/latex-naive-export.typ
+++ b/tests/math/latex-naive-export.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/math/latex-naive-export.typ
+++ b/tests/math/latex-naive-export.typ
@@ -1,0 +1,7 @@
+#set text(lang: "en")
+#outline()
+#set heading(numbering: "1.")
+#heading(level: 1)[Math (naive)] #label("org0000000")
+This is inline Math: $a^2=b$. The following two statements are not inlined.
+
+$ a + b $ $ a=-2 $

--- a/tests/math/latex-no-export.org
+++ b/tests/math/latex-no-export.org
@@ -1,0 +1,13 @@
+#+BIND: org-typst-from-latex-fragment nil
+#+BIND: org-typst-from-latex-environment nil
+
+* Math (no export)
+
+\begin{equation}                        % arbitrary environments,
+x=\sqrt{b}                              % even tables, figures, etc
+\end{equation}
+
+This is inline Math, but there is nothing here. $a^2=b$. The following two
+statements are not there either, strange.
+
+\( a + b \) \[ a=-2 \]

--- a/tests/math/latex-no-export.typ
+++ b/tests/math/latex-no-export.typ
@@ -1,0 +1,6 @@
+#set text(lang: "en")
+#outline()
+#set heading(numbering: "1.")
+#heading(level: 1)[Math (no export)] #label("org0000000")
+This is inline Math, but there is nothing here. . The following two
+statements are not there either, strange.

--- a/tests/math/latex-no-export.typ
+++ b/tests/math/latex-no-export.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/math/latex-pandoc-export.org
+++ b/tests/math/latex-pandoc-export.org
@@ -1,4 +1,7 @@
-* Math
+#+BIND: org-typst-from-latex-fragment org-typst-from-latex-with-pandoc
+#+BIND: org-typst-from-latex-environment org-typst-from-latex-with-pandoc
+
+* Math (pandoc)
 
 \begin{equation}                        % arbitrary environments,
 x=\sqrt{b}                              % even tables, figures, etc

--- a/tests/math/latex-pandoc-export.typ
+++ b/tests/math/latex-pandoc-export.typ
@@ -1,0 +1,9 @@
+#set text(lang: "en")
+#outline()
+#set heading(numbering: "1.")
+#heading(level: 1)[Math (pandoc)] #label("org0000000")
+$ x = sqrt(b) $
+
+This is inline Math: $a^2 = b$. The following two statements are not inlined.
+
+$a + b$ $ a = - 2 $

--- a/tests/math/latex-pandoc-export.typ
+++ b/tests/math/latex-pandoc-export.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/property/drawer.typ
+++ b/tests/property/drawer.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/property/properties.typ
+++ b/tests/property/properties.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/table/normal.typ
+++ b/tests/table/normal.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/table/verbatim.typ
+++ b/tests/table/verbatim.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/test.el
+++ b/tests/test.el
@@ -1,6 +1,9 @@
 ;; -*- lexical-binding: t -*-
 (require 'vc-git)
 
+(when (not (interactive-p))
+  (set-face-foreground 'font-lock-builtin-face "pink"))
+
 (load (file-name-concat (vc-git-root default-directory) "ox-typst.el"))
 
 ;; Required by math tests

--- a/tests/test.el
+++ b/tests/test.el
@@ -126,23 +126,8 @@
                                           (buffer-substring-no-properties (point-min) (point-max))))
                                'success
                              'fail)
-                           (lambda () (diff-buffers typst-buffer typst-new-buffer)))))))
-
-              (result-compile
-               (if (not (file-exists-p typst-file))
-                   (list 'skip nil)
-                 (let* ((typst-output-buffer (format "*Output Typst %s*"
-                                                     (file-name-sans-extension org-file)))
-                        (exit-code (shell-command (format "typst c '%s'"
-                                                          (expand-file-name typst-file))
-                                                  (progn (when (get-buffer typst-output-buffer)
-                                                           (kill-buffer typst-output-buffer))
-                                                         typst-output-buffer))))
-                   (list (if (zerop exit-code) 'success 'fail)
-                         (lambda () (switch-to-buffer (get-buffer-create typst-output-buffer))))))))
-          (org-typst-test--report org-file (list
-                                            (cons "Transpile to Typst" result-transpile)
-                                            (cons "Compile Typst File" result-compile))))))
+                           (lambda () (diff-buffers typst-buffer typst-new-buffer))))))))
+          (org-typst-test--report org-file (list (cons "Transpile to Typst" result-transpile))))))
     (switch-to-buffer org-typst-test--report-buffer)
     (goto-char (point-max))
     (insert (format "\nTests: %d\nSucceeded: %d\nSkipped: %d\nFailed: %d\n"

--- a/tests/test.el
+++ b/tests/test.el
@@ -3,6 +3,9 @@
 
 (load (file-name-concat (vc-git-root default-directory) "ox-typst.el"))
 
+;; Required by math tests
+(setq org-export-allow-bind-keywords t)
+
 (defvar org-typst-test--tests-failed 0)
 (defvar org-typst-test--tests-skipped 0)
 (defvar org-typst-test--tests-succeeded 0)

--- a/tests/toc/default.typ
+++ b/tests/toc/default.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #set heading(numbering: "1.")
 #outline(title: none)

--- a/tests/toc/local.typ
+++ b/tests/toc/local.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #set heading(numbering: "1.")
 #heading(level: 1)[A] #label("org0000006")

--- a/tests/toc/max-depth.typ
+++ b/tests/toc/max-depth.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #set heading(numbering: "1.")
 #outline(title: none, depth: 2)

--- a/tests/toc/numbering.typ
+++ b/tests/toc/numbering.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")

--- a/tests/toc/skip.typ
+++ b/tests/toc/skip.typ
@@ -1,3 +1,6 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
+⁠```
 #set text(lang: "en")
 #set heading(numbering: "1.")
 #outline(title: none)


### PR DESCRIPTION
- Closes #3
- Closes #18 
- Closes #20 
- Closes #21

Users can now use the theme and syntax fields (like in Typst) and also have the ability to export their Emacs color scheme. This feature also required including files which are located outside of the Typst root (by default the same directory where the Org file is located). For now files which include other files might be non-movable, so you might not be able to re-compile the Typst files afterwards when moving the file. If all your files are in a project (e.g. git repo) everything works file (see tests for reference)

Additionally this PR also includes:
- fix for unescaped $
- custom LaTeX fragment/environment processing