### PR TITLE
Enhancements to cite processor

### DIFF
--- a/tests/etc/cite-outside.org
+++ b/tests/etc/cite-outside.org
@@ -1,0 +1,11 @@
+#+BIBLIOGRAPHY: ../link/cite.bib
+#+print_bibliography: :title "Custom Ttitle For The Bibliography"
+#+CITE_EXPORT: typst apa
+
+* Cite Outside
+
+Here is my cite [cite:@DUMMY:1]. But here is another cite with a
+different style [cite/ieee:@OTHER].
+
+However, the bibliography is outside of the current directory, thus the project
+root.

--- a/tests/etc/cite-outside.typ
+++ b/tests/etc/cite-outside.typ
@@ -1,0 +1,13 @@
+#let _ = ```typ
+exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/../" --input file-0\=/link/cite.bib
+⁠```
+#set text(lang: "en")
+#outline()
+#set heading(numbering: "1.")
+#bibliography(style: "apa", title: "Custom Ttitle For The Bibliography", "../link/cite.bib")
+#heading(level: 1)[Cite Outside] #label("org0000000")
+Here is my cite #cite(label("DUMMY:1")). But here is another cite with a
+different style #cite(label("OTHER"), style: "ieee").
+
+However, the bibliography is outside of the current directory, thus the project
+root.

--- a/tests/link/cite.org
+++ b/tests/link/cite.org
@@ -6,3 +6,6 @@
 
 Here is my cite [cite:@DUMMY:1]. But here is another cite with a
 different style [cite/ieee:@OTHER].
+
+
+We can also use the two cites in a single link [cite/ieee:@OTHER;@DUMMY:1].

--- a/tests/link/cite.typ
+++ b/tests/link/cite.typ
@@ -8,3 +8,6 @@ exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 #heading(level: 1)[Cite] #label("org0000000")
 Here is my cite #cite(label("DUMMY:1")). But here is another cite with a
 different style #cite(label("OTHER"), style: "ieee").
+
+
+We can also use the two cites in a single link #cite(label("OTHER"), style: "ieee")#cite(label("DUMMY:1"), style: "ieee").


### PR DESCRIPTION
I noticed that `org-typst-export-bibliography` did not process biliography files with `org-typst--as-typst-path`. As a result, compilation would fail if a bibliography file resided outside the compilation root. Furthermore combined citations, e.g. `[cite:@one;@two]`, were improperly translated. 

This PR fixes these issues. 