### PR TITLE
FEATURE: Initial Typst Header Functionality

### DIFF
--- a/ox-typst.el
+++ b/ox-typst.el
@@ -163,6 +163,11 @@ will result in `ox-typst' to apply the colors to the code block."
           (const :tag "Both" t))
   :group 'org-export-typst)
 
+(defcustom org-typst-default-header nil
+  "Specify the default typst content before any other content."
+  :type 'string
+  )
+
 (defvar org-typst--file-paths nil
   "List of file paths used by the Org file.")
 
@@ -223,6 +228,7 @@ will result in `ox-typst' to apply the colors to the code block."
             (?p "As PDF file" org-typst-export-to-pdf)))
   :options-alist
   '((:typst-format-drawer-function nil nil org-typst-format-drawer-function)
+    (:typst-header "TYPST_HEADER" nil org-typst-default-header newline) 
     (:typst-format-inlinetask-function nil
                                        nil
                                        org-typst-format-inlinetask-function)))
@@ -555,7 +561,8 @@ will result in `ox-typst' to apply the colors to the code block."
         (language (plist-get info :language))
         (email (when (plist-get info :with-email)
                  (plist-get info :email)))
-        (toc (plist-get info :with-toc)))
+        (toc (plist-get info :with-toc))
+        (typst-header (plist-get info :typst-header)))
     (concat
      (format "#let _ = ```typ
 exec %s
@@ -570,6 +577,7 @@ exec %s
               (format ", author: \"%s\"" (car author))))
         ")\n"))
      (when language (format "#set text(lang: \"%s\")\n" language))
+     (when typst-header (format "%s\n" typst-header))
      (when toc "#outline()\n")
      (format "#set heading(numbering: %s)\n"
              (org-typst--as-string org-typst-heading-numbering))


### PR DESCRIPTION
As far as I could tell, there was no way to insert any content/show rules before the first `#outline()`. This pull request add an additional keyword `TYPST_HEADER` which can be used to insert typst code before `#outline()`. This is similar to the behavior of `LATEX_HEADER`. This allows emacs to manage the TOC, rather than typst.

You can use it with a custom template like so:

```org
#+typst_header: #import "mytemplate.typ": conf
#+typst_header: #show: doc => conf(title: "My cool document", doc)
```

I did run the tests and they all passed except for 2 (?) that also didn't pass before the changes. Let me know what you think!