### PR TITLE
feat: improve citations

### DIFF
--- a/tests/link/cite.org
+++ b/tests/link/cite.org
@@ -1,8 +1,7 @@
 #+BIBLIOGRAPHY: ./cite.bib
-#+print_bibliography: :title "Custom Ttitle For The Bibliography"
+#+print_bibliography: :title "Custom Title For The Bibliography"
 #+CITE_EXPORT: typst apa
 
 * Cite
 
-Here is my cite [cite:@DUMMY:1]. But here is another cite with a
-different style [cite/ieee:@OTHER].
+Here is my cite [cite:@DUMMY:1 p. 233]. [cite/text:@OTHER] agrees.

--- a/tests/link/cite.typ
+++ b/tests/link/cite.typ
@@ -4,7 +4,6 @@ exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 #set text(lang: "en")
 #outline()
 #set heading(numbering: "1.")
-#bibliography(style: "apa", title: "Custom Ttitle For The Bibliography", ("cite.bib"))
+#bibliography(style: "apa", title: "Custom Title For The Bibliography", ("cite.bib"))
 #heading(level: 1)[Cite] #label("org0000000")
-Here is my cite #cite(label("DUMMY:1")). But here is another cite with a
-different style #cite(label("OTHER"), style: "ieee").
+Here is my cite #cite(label("DUMMY:1"), supplement: "p. 233"). #cite(label("OTHER"), form: "prose") agrees.


### PR DESCRIPTION
Translates extra elements in org-cite entries:
- post-notes/suffixes ("supplements" in Typst lingo); and
- styles, which correctly match to[ "forms" in Typst](https://typst.app/docs/reference/model/cite/).

Also fixes error in citations with multiple references (supersedes the second part of https://github.com/jmpunkt/ox-typst/pull/28).