### PR TITLE
Fix Invalid Citation Styles

### DIFF
--- a/ox-typst.el
+++ b/ox-typst.el
@@ -922,17 +922,19 @@ The resulting string will contain a \\u{XXXX} for every char specified in CHARS.
   "Construct Typst string with content STRING.
 
 The STRING will escape every occurrence of `\"'.  Normally the STRING is
-trimmed, but can be disabled with NO-TRIM."
+trimmed, but can be disabled with NO-TRIM.  If STRING is the symbol `none', then
+the Typst value for `none' is returned."
   (when string
-    (let* ((actual-string (cond ((stringp string) string)
-                                ((symbolp string) (symbol-name string))
-                                (t (error "Unsupported type %s of %s" (type-of string) string))))
-           (escaped (org-typst--escape '("\"") actual-string)))
-      (concat "\""
-              (if no-trim
-                  escaped
-                (org-trim escaped))
-              "\""))))
+    (if (equal string 'none)        "none"
+      (let* ((actual-string (cond ((stringp string) string)
+                                  ((symbolp string) (symbol-name string))
+                                  (t (error "Unsupported type %s of %s" (type-of string) string))))
+             (escaped (org-typst--escape '("\"") actual-string)))
+        (concat "\""
+                (if no-trim
+                    escaped
+                  (org-trim escaped))
+                "\"")))))
 
 (defun org-typst--language (language)
   "Map Org LANGUAGE to Typst language for source blocks.
@@ -977,12 +979,15 @@ start range of the timestamp is extracted."
               day))))
 
 (defun org-typst--as-cite-form (style)
-  "Convert STYLE from Emacs citation style to Typst form."
+  "Convert STYLE from Emacs citation style to Typst form.
+
+Possible types are either strings which are supported by Typst or the `none'
+symbol.  See the Typst documentation for the supported values."
   (pcase style
     ("text" "prose")
     ("author" "author")
-    ("noauthor" "date")
-    ("nocite" "none")
+    ("noauthor" "year")
+    ("nocite" 'none)
     (s (warn "Citation style '%s' doesn't have an equivalent in Typst; using 'normal'." s) "normal")))
 
 (defun org-typst--common-paths (dir)

--- a/tests/link/cite.org
+++ b/tests/link/cite.org
@@ -4,4 +4,19 @@
 
 * Cite
 
-Here is my cite [cite:@DUMMY:1 p. 233]. [cite/text:@OTHER] agrees.
+There are many ways to cite something. Here is a single cite [cite:@OTHER]. It
+is also possible to cite two times in a single element [cite:@OTHER;@DUMMY:1].
+We can also change the style of a single cite [cite/noauthor:@OTHER].
+Or add a suffix to the cite, like a page or paragraph [cite:@DUMMY:1 p. 233].
+
+It is also possible to use all features at the same time or mix them
+[cite/text:@OTHER;@DUMMY:1 p. 1337].
+
+** Cite Styles
+
+We map the style of Emacs to Typst:
+- [cite/text:@OTHER]
+- [cite/author:@OTHER]
+- [cite/noauthor:@OTHER]
+- [cite/nocite:@OTHER]
+- [cite/thistextdoesnotmakeanysense:@OTHER]

--- a/tests/link/cite.typ
+++ b/tests/link/cite.typ
@@ -5,5 +5,14 @@ exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 #outline()
 #set heading(numbering: "1.")
 #bibliography(style: "apa", title: "Custom Title For The Bibliography", ("cite.bib"))
-#heading(level: 1)[Cite] #label("org0000000")
-Here is my cite #cite(label("DUMMY:1"), supplement: "p. 233"). #cite(label("OTHER"), form: "prose") agrees.
+#heading(level: 1)[Cite] #label("org0000003")
+There are many ways to cite something. Here is a single cite #cite(label("OTHER")). It
+is also possible to cite two times in a single element #cite(label("OTHER"))#cite(label("DUMMY:1")).
+We can also change the style of a single cite #cite(label("OTHER"), form: "year").
+Or add a suffix to the cite, like a page or paragraph #cite(label("DUMMY:1"), supplement: "p. 233").
+
+It is also possible to use all features at the same time or mix them
+#cite(label("OTHER"), form: "prose")#cite(label("DUMMY:1"), supplement: "p. 1337", form: "prose").
+#heading(level: 2)[Cite Styles] #label("org0000000")
+We map the style of Emacs to Typst:
+#list(list.item[#cite(label("OTHER"), form: "prose")])#list(list.item[#cite(label("OTHER"), form: "author")])#list(list.item[#cite(label("OTHER"), form: "year")])#list(list.item[#cite(label("OTHER"), form: none)])#list(list.item[#cite(label("OTHER"), form: "normal")])


### PR DESCRIPTION
The current list of citation styles does not reflect the actual possibilities in Typst. Furthermore, the `none` value could not be represented correctly. This fixes the the following things:

- replace `"date"` with `"year"` and `"none"` with `'none`
- allow string to emit the value `none` 