### PR TITLE
More feature-complete export of tables: table.header(), table.hline(), and align()

### DIFF
--- a/ox-typst.el
+++ b/ox-typst.el
@@ -560,8 +560,25 @@ will result in `ox-typst' to apply the colors to the code block."
 (defun org-typst-table-cell (_table-cell contents _info)
   (format "[%s]," (or contents "")))
 
-(defun org-typst-table-row (_table-row contents _info)
-  contents)
+(defun org-typst-table-row (table-row contents info)
+  (concat
+   (when (org-export-table-row-starts-header-p table-row info)
+     "table.header(")
+   (if (eq (org-element-property :type table-row) 'rule)
+       (if (or
+            ;; Assume general styling of tables and
+            ;; don’t write hline for:
+            ;; hline delimiting last row of header:
+            (org-export-table-row-ends-header-p
+	     (org-export-get-previous-element table-row info) info)
+            ;; hline at bottom of table:
+            (not (org-export-get-next-element table-row info)))
+           ""
+         "table.hline(),")
+     contents)
+   (when (org-export-table-row-ends-header-p table-row info)
+     "),")))
+
 
 (defun org-typst-target (target contents info)
   (org-typst--label contents target info))

--- a/ox-typst.el
+++ b/ox-typst.el
@@ -551,7 +551,17 @@ will result in `ox-typst' to apply the colors to the code block."
     (if (eq (org-element-property :type table) 'org)
         ;;org
         (org-typst--figure
-         (format "#table(columns: %s, %s)" columns contents)
+         (format "#table(columns: %s, %s%s)"
+                 columns
+                 (concat
+                  "align: ("
+                  (mapconcat (lambda (table-cell)
+                               (format "%s" (org-export-table-cell-alignment
+		                             table-cell info)))
+                             (org-html-table-first-row-data-cells table info)
+                             ",")
+                  "),\n")
+                 contents)
          table
          info)
       ;; table.el


### PR DESCRIPTION
table.header() is best practice in Typst for styling and accessibility

This uses org-export heuristics for determining rows that should go in
the header.

It also prints explicit table rules as table.hline(), but not the rule
at the bottom of the header and at the bottom of the table (it is
assumed that the user can use a default style for this).

Inspiration for this still simplified implementation from ox-html and ox-latex.