### PR TITLE
Show links without footnotes

### DIFF
--- a/ox-typst.el
+++ b/ox-typst.el
@@ -451,13 +451,9 @@ will result in `ox-typst' to apply the colors to the code block."
      ;; Other like HTTP (external)
      (t
       (let ((link-typst (org-typst--as-string (org-element-property :raw-link link))))
-        (format "#link(%s)%s"
-                link-typst
-                (if contents
-                    (format "[%s] #footnote(link(%s))"
-                            (org-trim contents)
-                            link-typst)
-                  "")))))))
+        (if contents
+            (format "#link(%s)[%s]" link-typst (org-trim contents))
+          (format "#link(%s)" link-typst)))))))
 
 (defun org-typst-node-property (_node-property _contents _info)
   (message "// todo: org-typst-node-property"))

--- a/ox-typst.el
+++ b/ox-typst.el
@@ -163,7 +163,8 @@ will result in `ox-typst' to apply the colors to the code block."
           (const :tag "Both" t))
   :group 'org-export-typst)
 
-(defcustom org-typst-default-header nil
+(defcustom org-typst-default-header "#show link: set text(fill: blue, weight: 700)
+#show link: underline"
   "Specify the default Typst content before any other content."
   :type 'string
   :group 'org-export-typst)

--- a/tests/begin/center.typ
+++ b/tests/begin/center.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Center] #label("org0000000")

--- a/tests/begin/export.typ
+++ b/tests/begin/export.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #set page(paper: "a4")

--- a/tests/begin/no-smart-quotes.typ
+++ b/tests/begin/no-smart-quotes.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[No Smart Quotes] #label("org0000000")

--- a/tests/begin/quote.typ
+++ b/tests/begin/quote.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Quote] #label("org0000008")

--- a/tests/begin/smart-quote.typ
+++ b/tests/begin/smart-quote.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Smart Quotes] #label("org0000000")

--- a/tests/begin/verse.typ
+++ b/tests/begin/verse.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Verse] #label("org0000001")

--- a/tests/clock/item.typ
+++ b/tests/clock/item.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Clock] #label("org0000003")

--- a/tests/clock/schedule.typ
+++ b/tests/clock/schedule.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Schedule] #label("org0000003")

--- a/tests/clock/table.typ
+++ b/tests/clock/table.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Clocktable] #label("org0000010")

--- a/tests/code/block.typ
+++ b/tests/code/block.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Block] #label("org0000001")

--- a/tests/code/different-theme.typ
+++ b/tests/code/different-theme.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-3=/different-theme-syntax.yml --input file-2=/different-theme-color.xml --input file-1=/different-theme-syntax.yml --input file-0=/different-theme-color.xml
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Override Listing Theme] #label("org0000018")

--- a/tests/code/engrave-with-emacs.typ
+++ b/tests/code/engrave-with-emacs.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Emacs Syntax Highlighting] #label("org0000001")

--- a/tests/code/inline-block.typ
+++ b/tests/code/inline-block.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Inline] #label("org0000000")

--- a/tests/code/inline.typ
+++ b/tests/code/inline.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Inline] #label("org0000000")

--- a/tests/code/theme-foreground-background.typ
+++ b/tests/code/theme-foreground-background.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-0=/different-theme-color.xml
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Theme With Foreground And Background] #label("org0000001")

--- a/tests/custom/subtree-export.typ
+++ b/tests/custom/subtree-export.typ
@@ -3,6 +3,8 @@ exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set document(title: "heading level 2")
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #set heading(numbering: "1.")
 Content A
 #heading(level: 1)[heading relative level 1] #label("org0000000")

--- a/tests/etc/entities.typ
+++ b/tests/etc/entities.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Entities] #label("org0000000")

--- a/tests/etc/export-snippet.typ
+++ b/tests/etc/export-snippet.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Export Snippet] #label("org0000000")

--- a/tests/etc/fixed.typ
+++ b/tests/etc/fixed.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Fixed Width] #label("org0000000")

--- a/tests/etc/heading.typ
+++ b/tests/etc/heading.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[\u{23}1 Heading] #label("org0000000")

--- a/tests/etc/include.typ
+++ b/tests/etc/include.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Fixed Width] #label("org0000000")

--- a/tests/etc/inlinetask.typ
+++ b/tests/etc/inlinetask.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[some tiny task] #label("org0000000")

--- a/tests/etc/linebreak.typ
+++ b/tests/etc/linebreak.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Linebreak] #label("org0000000")

--- a/tests/etc/meta-informatation.typ
+++ b/tests/etc/meta-informatation.typ
@@ -3,6 +3,8 @@ exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set document(title: "My Cool Typst", author: "Me You")
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Section] #label("org0000000")

--- a/tests/etc/override-root-path.typ
+++ b/tests/etc/override-root-path.typ
@@ -2,6 +2,8 @@
 exec typst c --root .                                  $0
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Test Root] #label("org0000000")

--- a/tests/etc/theme.typ
+++ b/tests/etc/theme.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 // example theme inspired by the modus-theme

--- a/tests/figure/figure-with-reference.typ
+++ b/tests/figure/figure-with-reference.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-0=/black.png
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Figure] #label("org0000002")

--- a/tests/figure/figure.typ
+++ b/tests/figure/figure.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-0=/black.png
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Figure] #label("org0000002")

--- a/tests/figure/image-outside.typ
+++ b/tests/figure/image-outside.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/../" --input file-0=/black.png
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Image Outside of Typst Root] #label("org0000001")

--- a/tests/figure/image-remote.typ
+++ b/tests/figure/image-remote.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-0=/black.png
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Remote Image] #label("org0000007")

--- a/tests/issues/21.typ
+++ b/tests/issues/21.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Dollar Is Not Escaped] #label("org0000006")

--- a/tests/link/block.typ
+++ b/tests/link/block.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[First Page] #label("org0000002")

--- a/tests/link/cite-multiple.typ
+++ b/tests/link/cite-multiple.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-1=/cite-other.bib --input file-0=/cite.bib
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #bibliography(style: "apa", (sys.inputs.file-0, sys.inputs.file-1))

--- a/tests/link/cite.typ
+++ b/tests/link/cite.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./" --input file-0=/cite.bib
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #bibliography(style: "apa", title: "Custom Title For The Bibliography", (sys.inputs.file-0))

--- a/tests/link/file.typ
+++ b/tests/link/file.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[File Links] #label("org0000000")

--- a/tests/link/footnote.typ
+++ b/tests/link/footnote.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Footnote] #label("org0000003")

--- a/tests/link/headline.typ
+++ b/tests/link/headline.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Headline Name] #label("org0000000")

--- a/tests/link/link-external.typ
+++ b/tests/link/link-external.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Link] #label("org0000000")

--- a/tests/link/link-external.typ
+++ b/tests/link/link-external.typ
@@ -5,6 +5,6 @@ exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Link] #label("org0000000")
-Maybe found here #link("http://google.com")[Google] #footnote(link("http://google.com")) :)
+Maybe found here #link("http://google.com")[Google] :)
 
 Or we put a link here #link("https://google.com").

--- a/tests/link/link-internal.typ
+++ b/tests/link/link-internal.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Link in Headline ] #label("org0000000")

--- a/tests/link/property.typ
+++ b/tests/link/property.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Section One] #label("org0000000")

--- a/tests/link/radio.typ
+++ b/tests/link/radio.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Radio Target] #label("org0000000")

--- a/tests/list/checkbox.typ
+++ b/tests/list/checkbox.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Checkbox] #label("org0000000")

--- a/tests/list/description.typ
+++ b/tests/list/description.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Description] #label("org0000000")

--- a/tests/list/enumerated.typ
+++ b/tests/list/enumerated.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Enumerated] #label("org0000000")

--- a/tests/list/plain.typ
+++ b/tests/list/plain.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Plain] #label("org0000000")

--- a/tests/math/alternative.typ
+++ b/tests/math/alternative.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Math] #label("org0000000")

--- a/tests/math/latex-naive-export.typ
+++ b/tests/math/latex-naive-export.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Math (naive)] #label("org0000000")

--- a/tests/math/latex-no-export.typ
+++ b/tests/math/latex-no-export.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Math (no export)] #label("org0000000")

--- a/tests/math/latex-pandoc-export.typ
+++ b/tests/math/latex-pandoc-export.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Math (pandoc)] #label("org0000000")

--- a/tests/property/drawer.typ
+++ b/tests/property/drawer.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Drawer] #label("org0000001")

--- a/tests/property/properties.typ
+++ b/tests/property/properties.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Properties] #label("org0000000")

--- a/tests/table/normal.typ
+++ b/tests/table/normal.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Table] #label("org0000001")

--- a/tests/table/verbatim.typ
+++ b/tests/table/verbatim.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #heading(level: 1)[Table] #label("org0000001")

--- a/tests/toc/default.typ
+++ b/tests/toc/default.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #set heading(numbering: "1.")
 #outline(title: none)
 #heading(level: 1)[A] #label("org0000007")

--- a/tests/toc/local.typ
+++ b/tests/toc/local.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #set heading(numbering: "1.")
 #heading(level: 1)[A] #label("org0000006")
 #heading(level: 2)[A1] #label("org0000003")

--- a/tests/toc/max-depth.typ
+++ b/tests/toc/max-depth.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #set heading(numbering: "1.")
 #outline(title: none, depth: 2)
 #heading(level: 1)[A] #label("org0000006")

--- a/tests/toc/numbering.typ
+++ b/tests/toc/numbering.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #outline()
 #set heading(numbering: "1.")
 #outline(title: none)

--- a/tests/toc/skip.typ
+++ b/tests/toc/skip.typ
@@ -2,6 +2,8 @@
 exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
 ⁠```
 #set text(lang: "en")
+#show link: set text(fill: blue, weight: 700)
+#show link: underline
 #set heading(numbering: "1.")
 #outline(title: none)
 #heading(level: 1)[A] #label("org0000006")


### PR DESCRIPTION
As described in https://github.com/jmpunkt/ox-typst/discussions/49, the current way ox-typst converts links is likely a bug. For the current behaviour, consider the following Org file [tests/link/link-external.org](https://github.com/jmpunkt/ox-typst/blob/ac8893c79fa85a92a9251a695776971526ba8d76/tests/link/link-external.org):

```org
* Link

Maybe found here [[http://google.com][Google]] :)

Or we put a link here https://google.com.
```

and its typst output [tests/link/link-exernal.typ](https://github.com/jmpunkt/ox-typst/blob/ac8893c79fa85a92a9251a695776971526ba8d76/tests/link/link-external.typ) (note the footnote):

```typst
#let _ = ```typ
exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
⁠```
#set text(lang: "en")
#outline()
#set heading(numbering: "1.")
#heading(level: 1)[Link] #label("org0000000")
Maybe found here #link("http://google.com")[Google] #footnote(link("http://google.com")) :)

Or we put a link here #link("https://google.com").
```

The behaviour after this PR generates the current typst file:
```typst
#let _ = ```typ
exec typst c "$0" --root "$(readlink -f "$0" | xargs dirname)/./"
⁠```
#set text(lang: "en")
#show link: set text(fill: blue, weight: 700)
#show link: underline
#outline()
#set heading(numbering: "1.")
#heading(level: 1)[Link] #label("org0000000")
Maybe found here #link("http://google.com")[Google] :)

Or we put a link here #link("https://google.com").
```

Diff:
```diff
4a5,6
> #show link: set text(fill: blue, weight: 700)
> #show link: underline
8c10
< Maybe found here #link("http://google.com")[Google] #footnote(link("http://google.com")) :)
---
> Maybe found here #link("http://google.com")[Google] :)
```

So there are 2 changes in this PR:
1. remove footnote - fc9a496cefba2885ca7a2127c9bfaacebbfcf209
2. change default typst header (`set text(fill: blue, weight: 700)` and `underline`). I got these defaults from from https://typst.app/play/, those seem like reasonable defaults - b226e312228a97a8f489c5e308d032f4d591e1b2