### PR TITLE
Update packages to Latest Versions for Org, Typst, and Emacs

### DIFF
--- a/.github/workflows/elisp-tests.yml
+++ b/.github/workflows/elisp-tests.yml
@@ -1,14 +1,14 @@
 name: ELisp Tests
 
 on:
-  workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:
   nix-matrix:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     outputs:
       matrix: ${{ steps.set-matrix.outputs.matrix }}
     steps:
@@ -23,7 +23,6 @@ jobs:
   build:
     needs: nix-matrix
     runs-on: ${{ matrix.image }}
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     strategy:
       matrix:
         include: ${{ fromJSON(needs.nix-matrix.outputs.matrix) }}

--- a/.github/workflows/nix-tests.yml
+++ b/.github/workflows/nix-tests.yml
@@ -1,14 +1,14 @@
 name: Nix Tests
 
 on:
-  workflow_dispatch:
   push:
+    branches:
+      - main
   pull_request:
 
 jobs:
   check:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name
     steps:
       - uses: actions/checkout@v6
       - uses: nixbuild/nix-quick-install-action@v29

--- a/flake.lock
+++ b/flake.lock
@@ -256,14 +256,27 @@
         "url": "https://ftp.gnu.org/gnu/emacs/emacs-30.1.tar.xz"
       }
     },
+    "emacs-30-2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1755161604,
+        "narHash": "sha256-W2eZ+cNQhi/fMeRkwOqSKU7Vzvp43WUOpiwaLLNEXtg=",
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-30.2.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://ftp.gnu.org/gnu/emacs/emacs-30.2.tar.xz"
+      }
+    },
     "emacs-release-snapshot": {
       "flake": false,
       "locked": {
-        "lastModified": 1749386846,
-        "narHash": "sha256-ZrFOkMTVDNBJHMaD5eLdc66IykxbuJlHTQkduZyB0CU=",
+        "lastModified": 1775825957,
+        "narHash": "sha256-WUcH9mOqq6knniX7gd+bk9z/wpEbWnci6DPmncUkxqA=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "37de076017a7967296bb80a4282a46e3de75322f",
+        "rev": "fe90f2d87ecd65a671ac884dcf7be3692d5ae184",
         "type": "github"
       },
       "original": {
@@ -276,11 +289,11 @@
     "emacs-snapshot": {
       "flake": false,
       "locked": {
-        "lastModified": 1749451212,
-        "narHash": "sha256-PH6LVlNS28L0tX3YFkHRcvdplI4oiw425D5mZtSaGio=",
+        "lastModified": 1776061262,
+        "narHash": "sha256-VW6Adn++KMEnBzSBQ3pazuvf8/J7WUhMffUTkiem1FM=",
         "owner": "emacs-mirror",
         "repo": "emacs",
-        "rev": "3c04806b44843e2e07ff3344e2b3f68ffc62575a",
+        "rev": "7d07690e5dade398da8a26805744f8bf1daafe8c",
         "type": "github"
       },
       "original": {
@@ -345,18 +358,20 @@
         "emacs-29-3": "emacs-29-3",
         "emacs-29-4": "emacs-29-4",
         "emacs-30-1": "emacs-30-1",
+        "emacs-30-2": "emacs-30-2",
         "emacs-release-snapshot": "emacs-release-snapshot",
         "emacs-snapshot": "emacs-snapshot",
         "flake-compat": "flake-compat",
         "flake-utils": "flake-utils",
-        "nixpkgs": "nixpkgs"
+        "nixpkgs": "nixpkgs",
+        "nixpkgs-glibc-2-39": "nixpkgs-glibc-2-39"
       },
       "locked": {
-        "lastModified": 1749641194,
-        "narHash": "sha256-1KO+ssnABRwkOI9HOXhpWfdTeYY7GA4XbxgFOkcChds=",
+        "lastModified": 1776076586,
+        "narHash": "sha256-BTr6vQ9Q3ARhSdplnO39L4PKTo01hT4Uy9VfbzWKKFk=",
         "owner": "purcell",
         "repo": "nix-emacs-ci",
-        "rev": "1655674882fd5022ce2c1bac52e4cb87c579bac0",
+        "rev": "c5222d0cf8dbe0ff5a4badf166e80fdb808829f2",
         "type": "github"
       },
       "original": {
@@ -367,11 +382,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1748662220,
-        "narHash": "sha256-7gGa49iB9nCnFk4h/g9zwjlQAyjtpgcFkODjcOQS0Es=",
+        "lastModified": 1774855581,
+        "narHash": "sha256-YkreHeMgTCYvJ5fESV0YyqQK49bHGe2B51tH6claUh4=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "59138c7667b7970d205d6a05a8bfa2d78caa3643",
+        "rev": "15c6719d8c604779cf59e03c245ea61d3d7ab69b",
         "type": "github"
       },
       "original": {
@@ -380,13 +395,28 @@
         "type": "indirect"
       }
     },
+    "nixpkgs-glibc-2-39": {
+      "locked": {
+        "lastModified": 1759070547,
+        "narHash": "sha256-JVZl8NaVRYb0+381nl7LvPE+A774/dRpif01FKLrYFQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "type": "github"
+      },
+      "original": {
+        "id": "nixpkgs",
+        "rev": "647e5c14cbd5067f44ac86b74f014962df460840",
+        "type": "indirect"
+      }
+    },
     "nixpkgs_2": {
       "locked": {
-        "lastModified": 1749285348,
-        "narHash": "sha256-frdhQvPbmDYaScPFiCnfdh3B/Vh81Uuoo0w5TkWmmjU=",
+        "lastModified": 1776169885,
+        "narHash": "sha256-l/iNYDZ4bGOAFQY2q8y5OAfBBtrDAaPuRQqWaFHVRXM=",
         "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "3e3afe5174c561dee0df6f2c2b2236990146329f",
+        "rev": "4bd9165a9165d7b5e33ae57f3eecbcb28fb231c9",
         "type": "github"
       },
       "original": {
@@ -396,19 +426,19 @@
         "type": "github"
       }
     },
-    "org-9-7-15": {
+    "org-9-8-3": {
       "flake": false,
       "locked": {
-        "lastModified": 1730445956,
-        "narHash": "sha256-mZAypZ8bxWLjnCZX/4XE5Qw2+ieFCyzY/YQnZF1n9+Q=",
+        "lastModified": 1776494943,
+        "narHash": "sha256-eFDQnbE2SvnOTrs5h0XECz6+JJmzTluISzLNmfK8Y28=",
         "owner": "emacs-straight",
         "repo": "org-mode",
-        "rev": "a1df10f679a72fe75c3d95d1e41b5fdb689fe22e",
+        "rev": "5d711684f1757598942e0a5fafd9712f2a6dc667",
         "type": "github"
       },
       "original": {
         "owner": "emacs-straight",
-        "ref": "release_9.7.15",
+        "ref": "release_9.8.3",
         "repo": "org-mode",
         "type": "github"
       }
@@ -416,11 +446,11 @@
     "org-main": {
       "flake": false,
       "locked": {
-        "lastModified": 1749490267,
-        "narHash": "sha256-n8yjSHz6z28KiusjSss0sDlXvS9WaOm5mYBd01inL/o=",
+        "lastModified": 1776541374,
+        "narHash": "sha256-OlpQnXGUcyl731UeVuTPHztOSFcdDFtMBq5vF5JFFao=",
         "owner": "emacs-straight",
         "repo": "org-mode",
-        "rev": "ecde809349c31184d10167b0b822ed13a6c2ceb4",
+        "rev": "0f5bcc5b9e9b8ebfe52562d731e14cecf276b44e",
         "type": "github"
       },
       "original": {
@@ -433,10 +463,10 @@
       "inputs": {
         "nix-emacs-ci": "nix-emacs-ci",
         "nixpkgs": "nixpkgs_2",
-        "org-9-7-15": "org-9-7-15",
+        "org-9-8-3": "org-9-8-3",
         "org-main": "org-main",
-        "typst-0-12-0": "typst-0-12-0",
-        "typst-0-13-1": "typst-0-13-1"
+        "typst-0-13-1": "typst-0-13-1",
+        "typst-0-14-2": "typst-0-14-2"
       }
     },
     "systems": {
@@ -454,19 +484,6 @@
         "type": "github"
       }
     },
-    "typst-0-12-0": {
-      "flake": false,
-      "locked": {
-        "lastModified": 1729288087,
-        "narHash": "sha256-ta69kqJM9kyRWJxykXOM5/fP1MTRO0V+ZnFdG0nKCiI=",
-        "type": "tarball",
-        "url": "https://github.com/typst/typst/releases/download/v0.12.0/typst-x86_64-unknown-linux-musl.tar.xz"
-      },
-      "original": {
-        "type": "tarball",
-        "url": "https://github.com/typst/typst/releases/download/v0.12.0/typst-x86_64-unknown-linux-musl.tar.xz"
-      }
-    },
     "typst-0-13-1": {
       "flake": false,
       "locked": {
@@ -478,6 +495,19 @@
       "original": {
         "type": "tarball",
         "url": "https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-unknown-linux-musl.tar.xz"
+      }
+    },
+    "typst-0-14-2": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1765562195,
+        "narHash": "sha256-+su2a5ookWediiqgV1Fu3bNkBwttap+2jJlcOBTFYX0=",
+        "type": "tarball",
+        "url": "https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-unknown-linux-musl.tar.xz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-unknown-linux-musl.tar.xz"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -9,8 +9,8 @@
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs?ref=nixos-unstable";
     nix-emacs-ci.url = "github:purcell/nix-emacs-ci";
-    "org-9-7-15" = {
-      url = "github:emacs-straight/org-mode?ref=release_9.7.15";
+    "org-9-8-3" = {
+      url = "github:emacs-straight/org-mode?ref=release_9.8.3";
       flake = false;
     };
     "org-main" = {
@@ -21,8 +21,8 @@
       url = "https://github.com/typst/typst/releases/download/v0.13.1/typst-x86_64-unknown-linux-musl.tar.xz";
       flake = false;
     };
-    "typst-0-12-0" = {
-      url = "https://github.com/typst/typst/releases/download/v0.12.0/typst-x86_64-unknown-linux-musl.tar.xz";
+    "typst-0-14-2" = {
+      url = "https://github.com/typst/typst/releases/download/v0.14.2/typst-x86_64-unknown-linux-musl.tar.xz";
       flake = false;
     };
   };
@@ -44,17 +44,17 @@
       "aarch64-darwin" = "macos-latest";
     };
     org-versions = [
-      "9.7.15"
+      "9.8.3"
       "main"
     ];
     emacs-versions = [
-      "30.1"
+      "30.2"
       "snapshot"
       "release-snapshot"
     ];
     typst-versions = [
       "0.13.1"
-      "0.12.0"
+      "0.14.2"
     ];
     buildTypst = {
       pkgs,


### PR DESCRIPTION
Ensures that ox-typst runs with the latest versions of the different tools. It also re-enables caching of Emacs, since we ran on a too old version for this.