### PR TITLE
ox-typst: add configurable checkbox rendering for unordered lists

### DIFF
--- a/ox-typst.el
+++ b/ox-typst.el
@@ -46,6 +46,30 @@ Check the documentation of your Typst version for supported arguments."
   :type 'string
   :group 'org-typst-export)
 
+(defcustom org-typst-unordered-list-checkbox-rendering 'inline
+  "How checkboxes in unordered lists are rendered.
+
+  `inline' (default) All items are emitted as a single #list()
+    block. Checkboxes are rendered using the Typst code defined in
+    `org-typst-checkbox-symbols' and prepended to each item's content.
+
+  `inline-plain' Like `inline', but checkboxes are emitted as simple text
+    markers ([X], [-], [ ]). This is ideal for Typst packages like \"cheq\"
+    which scan the document's plain text for these specific patterns.
+
+  `inline-raw' Like `inline', but checkboxes are wrapped in Typst's #raw()
+    function. This ensures they are rendered in monospace, equivalent to
+    using backticks in Typst.
+
+  `marker' Each item is wrapped in its own #list() call and the checkbox symbol
+    from `org-typst-checkbox-symbols' is passed via Typst's marker
+    attribute. Vertical spacing between items may appear excessive."
+  :group 'org-export-typst
+  :type '(choice (const :tag "Inline – custom symbols" inline)
+                 (const :tag "Inline – plain text" inline-plain)
+                 (const :tag "Inline – #raw() (monospace)" inline-raw)
+                 (const :tag "Marker – separate #list() calls" marker)))
+
 ;; TODO: Maybe use a different way to display checkboxes. Unicode most
 ;; likely wont work since there are no three checkbox like symbols
 ;; which share the same size.
@@ -340,16 +364,55 @@ will result in `ox-typst' to apply the colors to the code block."
   (format "#emph[%s]" contents))
 
 (defun org-typst-item (item contents info)
+  "Transcode an ITEM element from Org to Typst.
+CONTENTS holds the transcoded item content.  INFO is a plist with
+contextual information.
+
+For unordered lists the output depends on
+`org-typst-unordered-list-checkbox-rendering':
+- `inline': emits a list.item[] with the checkbox symbol from
+  `org-typst-checkbox-symbols' prepended to the content.
+- `inline-plain': like `inline', but uses plain text ([X], [-], [ ]).
+- `inline-raw': like `inline', but uses plain text ([X], [-], [ ]) wrapped into
+  #raw to make it be monospaced.
+- `marker': returns bare content only; the enclosing #list() wrapper
+  with the marker attribute is built by `org-typst-plain-list'."
   (when-let* ((parent (org-export-get-parent item))
               (trimmed (org-trim (if (stringp contents) contents ""))))
     (pcase (org-element-property :type parent)
-      ;; NOTE: unordered list items are all represented as single lists
-      ('unordered trimmed)
+      ('unordered
+       (pcase org-typst-unordered-list-checkbox-rendering
+         ('inline
+           (let* ((cb-type (org-element-property :checkbox item))
+                  (cb-symbol (cdr (assoc cb-type org-typst-checkbox-symbols))))
+             (if cb-symbol
+                 (format "list.item[%s#h(0.2em) %s]," cb-symbol trimmed)
+               (format "list.item[%s]," trimmed))))
+         ('inline-raw
+          (let* ((cb-type (org-element-property :checkbox item))
+                 (cb-raw (pcase cb-type
+                           ('on "#raw(\"[x]\")" )
+                           ('trans "#raw(\"[-]\")" )
+                           ('off "#raw(\"[ ]\")" )
+                           (_ nil))))
+            (if cb-raw
+                (format "list.item[%s %s]," cb-raw trimmed)
+              (format "list.item[%s]," trimmed))))
+         ('inline-plain
+          (let* ((cb-type (org-element-property :checkbox item))
+                 (cb-plain (pcase cb-type
+                             ('on "[x]" )
+                             ('trans "[-]" )
+                             ('off "[ ]" )
+                             (_ nil))))
+            (if cb-plain
+                (format "list.item[%s %s]," cb-plain trimmed)
+              (format "list.item[%s]," trimmed))))
+         (_ trimmed)))
       ('ordered (when-let* ((bullet-raw (org-element-property :bullet item)))
-                  (when (string-match "\\([0-9]+\\)\." bullet-raw)
+                  (when (string-match "\\([0-9]+\\)\\." bullet-raw)
                     (format "enum.item(%s)[%s],"
-                            (match-string 1 bullet-raw)
-                            trimmed))))
+                            (match-string 1 bullet-raw) trimmed))))
       ('descriptive (when-let* ((raw-tag (org-element-property :tag item))
                                 (tag (and raw-tag
                                           (org-export-data raw-tag info))))
@@ -462,25 +525,37 @@ will result in `ox-typst' to apply the colors to the code block."
   contents)
 
 (defun org-typst-plain-list (plain-list contents info)
+  "Transcode a PLAIN-LIST element from Org to Typst.
+CONTENTS holds the transcoded list items.  INFO is a plist with
+contextual information.
+
+Unordered lists are handled according to
+`org-typst-unordered-list-checkbox-rendering': `inline', `inline-plain' and
+`inline-raw' emit a single #list() block; `marker' wraps each item in its own
+#list() call."
   (pcase (org-element-property :type plain-list)
-    ;; NOTE: use a single list with a marker instead of a list with
-    ;;       list items
     ('unordered
-     (mapconcat
-      (lambda (item)
-        (when (eq (car item) 'item)
-          (let ((marker (cdr (assoc (org-element-property :checkbox item)
-                                    org-typst-checkbox-symbols)))
-                (item-content (org-trim (org-export-data item info))))
-            (if marker
-                (format "#list(marker: [%s], list.item[%s])"
-                        marker
-                        item-content)
-              (format "#list(list.item[%s])" item-content)))))
-      (cdr plain-list)))
+     (if (not (eq org-typst-unordered-list-checkbox-rendering 'marker))
+         (format "#list(\n%s\n)"
+                 (mapconcat (lambda (item)
+                              (org-export-data item info))
+                            (org-element-contents plain-list)
+                            "\n"))
+       (mapconcat
+        (lambda (item)
+          (when (eq (car item) 'item)
+            (let ((marker (cdr (assoc (org-element-property :checkbox item)
+                                      org-typst-checkbox-symbols)))
+                  (item-content (org-trim (org-export-data item info))))
+              (if marker
+                  (format "#list(marker: [%s], list.item[%s])"
+                          marker item-content)
+                (format "#list(list.item[%s])" item-content)))))
+        (cdr plain-list))))
     ('ordered (format "#enum(%s)" contents))
     ('descriptive (format "#terms(%s)" contents))
     (_ nil)))
+
 
 (defun org-typst-plain-text (contents info)
   (let ((with-smart-quotes (plist-get info :with-smart-quotes))

--- a/tests/list/checkbox.org
+++ b/tests/list/checkbox.org
@@ -1,5 +1,9 @@
+#+TYPST: #import "@preview/cheq:0.3.0": checklist
+#+TYPST: #show: checklist
+
 * Checkbox
 - [ ] One
+- This is different
 - [X] Two
 - [-] Other
   - [ ] OtherOne


### PR DESCRIPTION
This is a possible solution for #52.  Declaration: Used AI to help me write the code. Reviewed, tested and manually optimized the code. Not looked at the tests so far, waiting for what you think first.

And thanks for creating ox-typst, really cool.

### Description of Changes

Introduce `org-typst-unordered-list-checkbox-rendering' with three modes:

- `inline' (default): all items are grouped into a single #list() block with checkbox symbols from `org-typst-checkbox-symbols' prepended to each item's content, preserving Typst's native gap spacing.
- `inline-raw': like `inline', but emits raw markers ([X], [-], [ ]) to enable Typst show rules, e.g. via the "cheq" package.
- `marker': retains the previous behaviour of wrapping each item in its own #list() call with the checkbox passed via the marker attribute.
- Refactor `org-typst-item' and `org-typst-plain-list' accordingly and add docstrings to both functions.
- Fix escaped dot in ordered-list bullet regex (\\. instead of \.).

### What it looks like

- inline

<img width="445" height="128" alt="image" src="https://github.com/user-attachments/assets/fead09ff-dfaa-4aef-a1c8-c9a2b33ebf1c" />

- inline-raw

<img width="445" height="128" alt="image" src="https://github.com/user-attachments/assets/56490f32-e6a7-4f55-9132-e40dff979d14" />


- inline-raw with using cheq

<img width="445" height="128" alt="image" src="https://github.com/user-attachments/assets/bfdf9787-d800-453b-ae28-c8e8473b49a3" />


- marker

<img width="445" height="142" alt="image" src="https://github.com/user-attachments/assets/155b0631-676e-46b4-b51d-2a01c034c844" />

### Add a Changelog?

Could you add a CHANGELOG.org on main? Would be great to be able to document what is changed in a pull request. Nothing fancy just a simple one like:

```
* Changelog

** Planned

*** TODO Functions to show definitions and synonyms at once

** Unreleased

- =CHANGED= Changed headers to mimick Tor browser for better privacy.
- =CHANGED= Using if-let* and when-let* to be future proof.
- =FIXED= Moved .el file into a lisp directory. Else using the package with use-package and ~:vc~ leads to compile errors as there is no ~:files~, only ~:lisp-dir~.

** 0.1.0 - [2024-08-19 Mon] 

- =ADDED= ....
- =REMOVED= ....

** Remark

Type of changes:

- =Added= for new features.
- =Changed= for changes in existing functionality.
- =Deprecated= for soon-to-be removed features.
- =Removed= for now removed features.
- =Fixed= for any bug fixes.
- =Security= in case of vulnerabilities.

```

### Checkbox Symbols


Two new checkbox styles using em (to scale if font size changes) inspired by cheq:

With x for checked:

```
(setq org-typst-checkbox-symbols
      '((off . "#box(stroke: .05em + black, fill: white, height: .8em, width: .8em, baseline: .15em)")
        (on . "#box(stroke: .05em + black, fill: white, height: .8em, width: .8em, baseline: .15em, place(center + horizon, rotate(45deg, line(length: .65em, stroke: black + .1em))) + place(center + horizon, rotate(-45deg, line(length: .65em, stroke: black + .1em))))")
        (trans . "#box(stroke: .05em + black, fill: white, height: .8em, width: .8em, baseline: .15em, align(center + horizon, line(length: 0.5em, stroke: black + .1em)))")))
```
<img width="200" alt="image" src="https://github.com/user-attachments/assets/38b6b11b-e29f-4967-9b3a-ec483c409837" />

With checkmark for checked:

```
(setq org-typst-checkbox-symbols
      '((off . "#box(stroke: .05em + black, fill: white, height: .8em, width: .8em, baseline: .15em)")
        (on . "#box(stroke: .05em + black, fill: white, height: .8em, width: .8em, baseline: .15em, {box(move(dy: .48em, dx: 0.1em, rotate(45deg, reflow: false, line(length: 0.3em, stroke: black + .1em))));box(move(dy: .38em, dx: -0.05em, rotate(-45deg, reflow: false, line(length: 0.48em, stroke: black + .1em))))})")
        (trans . "#box(stroke: .05em + black, fill: white, height: .8em, width: .8em, baseline: .15em, align(center + horizon, line(length: 0.5em, stroke: black + .1em)))")))
```

<img width="200" alt="image" src="https://github.com/user-attachments/assets/679aa594-d2b8-42a7-8320-4394309f5fb7" />

        
     